### PR TITLE
Move parameters to view representation

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/js-src/de/bund/bfr/knime/fsklab/nodes/newjoiner/joiner.js
+++ b/de.bund.bfr.knime.fsklab.nodes/js-src/de/bund/bfr/knime/fsklab/nodes/newjoiner/joiner.js
@@ -22,9 +22,6 @@ joiner = function () {
 
   let _metadata;
 
-  let _firstModelMath;
-  let _secondModelMath;
-
   let _firstModelParameterMap = {};
   let _secondModelParameterMap = {};
 
@@ -44,6 +41,8 @@ joiner = function () {
 
   view.init = function (representation, value) {
 
+    console.log(representation);
+
     _representation = representation;
     _value = value;
 
@@ -60,9 +59,6 @@ joiner = function () {
 
     _firstModelName = value.firstModelName;
     _secondModelName = value.secondModelName;
-
-    _firstModelMath = JSON.parse(value.modelMath1);
-    _secondModelMath = JSON.parse(value.modelMath2);
 
     _modelScriptTree = JSON.parse(value.modelScriptTree);
 
@@ -337,28 +333,26 @@ joiner = function () {
     window.firstPortMap = {};
     window.secondPortMap = {};
 
-    if (_firstModelMath) {
-      for (param of _firstModelMath.parameter) {
-        if (!_firstModelParameterMap[param.id]) {
-          let port = createPort(param.id, param.dataType);
-          if (param.classification === "INPUT" || param.classification === "CONSTANT") {
-            port.group = "in";
-            firstModelInputParameters.push(port);
-          } else {
-            port.group = "out";
-            firstModelOutputParameters.push(port);
-          }
-
-          window.firstPortMap[param.id] = port;
-          _firstModelParameterMap[param.id] = param;
+    for (param of _representation.firstModelParameters) {
+      if (!_firstModelParameterMap[param.id]) {
+        let port = createPort(param.id, param.dataType);
+        if (param.classification === "INPUT" || param.classification === "CONSTANT") {
+          port.group = "in";
+          firstModelInputParameters.push(port);
+        } else {
+          port.group = "out";
+          firstModelOutputParameters.push(port);
         }
+
+        window.firstPortMap[param.id] = port;
+        _firstModelParameterMap[param.id] = param;
       }
     }
 
     let secondModelInputParameters = [];
     let secondModelOutputParameters = [];
 
-    for (param of _secondModelMath.parameter) {
+    for (param of _representation.secondModelParameters) {
       if (!_firstModelParameterMap[param.id]) {
         let port = createPort(param.id, param.dataType);
         if (param.classification === "INPUT" || param.classification === "CONSTANT") {

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/JoinerNodeSettings.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/JoinerNodeSettings.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.bund.bfr.knime.fsklab.FskPlugin;
 import de.bund.bfr.knime.fsklab.JoinRelation;
+import de.bund.bfr.metadata.swagger.Parameter;
 
 class JoinerNodeSettings {
 
@@ -38,30 +39,44 @@ class JoinerNodeSettings {
 
   String modelMetaData;
 
-  String modelMath1;
-  String modelMath2;
-
   JoinRelation[] connections;
+  Parameter[] firstModelParameters;
+  Parameter[] secondModelParameters;
 
   void load(final NodeSettingsRO settings) throws InvalidSettingsException {
 
     // Load connections from string in settings
-    String connectionString = settings.getString(CFG_JOIN_SCRIPT, "");
-    if (!connectionString.isEmpty()) {
+    if (settings.containsKey(CFG_JOIN_SCRIPT)) {
       try {
-        connections = MAPPER.readValue(connectionString, JoinRelation[].class);
+        connections = MAPPER.readValue(settings.getString(CFG_JOIN_SCRIPT), JoinRelation[].class);
       } catch (IOException err) {
         // do nothing
       }
     }
 
     modelMetaData = settings.getString(CFG_MODEL_METADATA, "");
-    modelMath1 = settings.getString(CFG_MODEL_MATH1, "");
-    modelMath2 = settings.getString(CFG_MODEL_MATH2, "");
+
+    if (settings.containsKey(CFG_MODEL_MATH1)) {
+      try {
+        firstModelParameters =
+            MAPPER.readValue(settings.getString(CFG_MODEL_MATH1), Parameter[].class);
+      } catch (IOException err) {
+        // do nothing
+      }
+    }
+
+    if (settings.containsKey(CFG_MODEL_MATH2)) {
+      try {
+        secondModelParameters =
+            MAPPER.readValue(settings.getString(CFG_MODEL_MATH2), Parameter[].class);
+      } catch (IOException err) {
+        // do nothing
+      }
+    }
   }
 
   void save(final NodeSettingsWO settings) {
-    
+
     // Save connections as a string in settings
     try {
       String connectionString = MAPPER.writeValueAsString(connections);
@@ -69,9 +84,19 @@ class JoinerNodeSettings {
     } catch (JsonProcessingException err) {
       // do nothing
     }
-    
+
     settings.addString(CFG_MODEL_METADATA, modelMetaData);
-    settings.addString(CFG_MODEL_MATH1, modelMath1);
-    settings.addString(CFG_MODEL_MATH2, modelMath2);
+    
+    try {
+      settings.addString(CFG_MODEL_MATH1, MAPPER.writeValueAsString(firstModelParameters));
+    } catch (JsonProcessingException err) {
+      // do nothing
+    }
+    
+    try {
+      settings.addString(CFG_MODEL_MATH2, MAPPER.writeValueAsString(secondModelParameters));
+    } catch (JsonProcessingException err) {
+      // do nothing
+    }
   }
 }

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/JoinerViewValue.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/JoinerViewValue.java
@@ -41,8 +41,6 @@ class JoinerViewValue extends JSONViewContent {
   private static final String CFG_ORIGINAL_MODEL_SCRIPT2 = "originalModelScript2";
   private static final String CFG_ORIGINAL_VISUALIZATION_SCRIPT2 = "originalVisualizationScript2";
   private static final String CFG_MODEL_METADATA = "ModelMetaData";
-  private static final String CFG_MODEL_MATH1 = "modelMath1";
-  private static final String CFG_MODEL_MATH2 = "modelMath2";
   private static final String CFG_JOINER_RELATION = "joinRelation";
   private static final String CFG_JSON_REPRESENTATION = "JSONRepresentation";
   private static final String CFG_MODELSCRIPT_TREE = "ModelScriptTree";
@@ -57,8 +55,6 @@ class JoinerViewValue extends JSONViewContent {
   public String firstModelViz;
   public String secondModelViz;
   public String modelMetaData;
-  public String modelMath1;
-  public String modelMath2;
   public JoinRelation[] joinRelations;
   public String jsonRepresentation;
   public String svgRepresentation;
@@ -92,13 +88,6 @@ class JoinerViewValue extends JSONViewContent {
     if (modelMetaData != null) {
       saveSettings(settings, CFG_MODEL_METADATA, modelMetaData);
     }
-
-    if (modelMath1 != null) {
-      saveSettings(settings, CFG_MODEL_MATH1, modelMath1);
-    }
-    if (modelMath2 != null) {
-      saveSettings(settings, CFG_MODEL_MATH2, modelMath2);
-    }
   }
 
   @Override
@@ -125,13 +114,6 @@ class JoinerViewValue extends JSONViewContent {
     // load meta data
     if (settings.containsKey(CFG_MODEL_METADATA)) {
       modelMetaData = getEObject(settings, CFG_MODEL_METADATA);
-    }
-
-    if (settings.containsKey(CFG_MODEL_MATH1)) {
-      modelMath1 = getEObject(settings, CFG_MODEL_MATH1);
-    }
-    if (settings.containsKey(CFG_MODEL_MATH2)) {
-      modelMath2 = getEObject(settings, CFG_MODEL_MATH2);
     }
   }
 


### PR DESCRIPTION
Remove the first and second model maths (model1Math and model2Math) in the Joiner
ViewValue and save instead the list of parameters of model 1 and model 2. Only the parameters are used in the view and the rest of the model math is unnecessary.  Also since the parameters are static and do not change, they are moved to the view representation.