### PR TITLE
Remove unused properties in de.bund.bfr.knime.fsklab.v1_9.FskPortObject

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/CombinedFskPortObject.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/CombinedFskPortObject.java
@@ -146,8 +146,6 @@ public class CombinedFskPortObject extends FskPortObject {
 
   public static final String[] RESOURCE_EXTENSIONS = new String[] {"txt", "RData", "csv"};
   
-  private static int numOfInstances = 0;
-  
   private static Random ran = new Random();
 
   public CombinedFskPortObject(final String model, final String param, final String viz,
@@ -159,8 +157,6 @@ public class CombinedFskPortObject extends FskPortObject {
     super(model, viz, modelMetadata, workspace, packages, generatedResourceFiles, environmentManager, plot, "");
     this.firstFskPortObject = firstFskPortObject;
     this.secondFskPortObject = secondFskPortObject;
-    objectNum = numOfInstances;
-    numOfInstances += 1;
   }
 
   public CombinedFskPortObject(final Optional<EnvironmentManager> environmentManager,
@@ -171,9 +167,6 @@ public class CombinedFskPortObject extends FskPortObject {
     this.secondFskPortObject = secondFskPortObject;
    
     this.generatedResourceFiles = new GeneratedResourceFiles();
-   
-    objectNum = numOfInstances;
-    numOfInstances += 1;
   }
 
   public CombinedFskPortObject(final String model, final String viz, final Model modelMetadata,
@@ -188,8 +181,6 @@ public class CombinedFskPortObject extends FskPortObject {
     this.modelMetadata = modelMetadata;
 
     this.generatedResourceFiles = new GeneratedResourceFiles();
-    objectNum = numOfInstances;
-    numOfInstances += 1;
   }
 
   @Override

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/FskPortObject.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/FskPortObject.java
@@ -148,9 +148,6 @@ public class FskPortObject implements PortObject {
   /** List of R packages. */
   public final List<String> packages;
 
-  private static int numOfInstances = 0;
-
-  public int objectNum;
   public int selectedSimulationIndex = 0;
   public final List<FskSimulation> simulations = new ArrayList<>();
 
@@ -170,9 +167,6 @@ public class FskPortObject implements PortObject {
     this.generatedResourceFiles = generatedResourceFiles;
     this.plot = plot;
     this.readme = StringUtils.defaultString(readme);
-
-    objectNum = numOfInstances;
-    numOfInstances += 1;
   }
 
   public FskPortObject(final Optional<EnvironmentManager> environmentManager, String readme, final List<String> packages)


### PR DESCRIPTION
#562 Remove the unused properties objectNum and numOfInstances only used
in constructor.