### PR TITLE
#115: python model from icpmf readable in 1.8.1

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/reader/ReaderNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/reader/ReaderNodeModel.java
@@ -455,7 +455,10 @@ class ReaderNodeModel extends NoInternalsModel {
 
       // Load scripts
       for (ArchiveEntry entry : entries) {
-        if (entry.getFormat().equals(scriptUri) && !entry.getDescriptions().isEmpty()) {
+        // workaround to make python models from version 1.7.2 compatible with 1.8.x
+        // those models had scripts that ended in ".r" instead of ".py"
+        if (( entry.getFormat().equals(scriptUri) || entry.getFormat().equals(URIS.get("r")) )
+            && !entry.getDescriptions().isEmpty()) {
           FskMetaDataObject fmdo = new FskMetaDataObject(entry.getDescriptions().get(0));
           ResourceType resourceType = fmdo.getResourceType();
 


### PR DESCRIPTION
had to insert a workaround in the reader node. Old python models had
their scripts ending with ".r" instead of the correct ".py".