### PR TITLE
112 python interpreter now taken from metadata

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/META-INF/MANIFEST.MF
+++ b/de.bund.bfr.knime.fsklab.nodes/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: com.fasterxml.jackson.core.jackson-annotations;bundle-version="2
  org.knime.js.core;bundle-version="[3.7.0,5.0.0)",
  org.knime.json;bundle-version="[3.7.1,5.0.0)",
  org.slf4j.api,
- org.knime.python2;bundle-version="[3.7.2,5.0.0)",
+ org.knime.python2;bundle-version="[3.7.2,4.0.0)",
  org.knime.core;bundle-version="[3.7.2,5.0.0)",
  org.knime.base;bundle-version="[3.7.2,5.0.0)",
  com.gmail.gcolaianni5.jris;bundle-version="1.0.0",

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/PythonScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/PythonScriptHandler.java
@@ -25,7 +25,9 @@ public class PythonScriptHandler extends ScriptHandler {
   public PythonScriptHandler(PythonVersionOption version) throws IOException {
     
     PythonKernelOptions m_kernelOptions = new PythonKernelOptions();
-    m_kernelOptions.setPythonVersionOption(version);
+    if(version != null) {
+      m_kernelOptions.setPythonVersionOption(version);
+    }
     controller = new PythonKernel(m_kernelOptions);
     
     // Currently only PythonPlotter is assigned as it is the only available for Python
@@ -34,11 +36,7 @@ public class PythonScriptHandler extends ScriptHandler {
 
   // if no version is given in the model metadata, use the KNIME preference setting
   public PythonScriptHandler() throws IOException {
-    // automatically receive information about used Python Version (2.7 or 3.x)
-    PythonKernelOptions m_kernelOptions = new PythonKernelOptions();
-    controller = new PythonKernel(m_kernelOptions);
-    
-    this.plotter = new PythonPlotter(controller);
+    this(null);
   }
   
   @Override

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/PythonScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/PythonScriptHandler.java
@@ -8,6 +8,7 @@ import org.knime.core.node.NodeLogger;
 import org.knime.core.util.FileUtil;
 import org.knime.python2.kernel.PythonKernel;
 import org.knime.python2.kernel.PythonKernelOptions;
+import org.knime.python2.kernel.PythonKernelOptions.PythonVersionOption;
 import de.bund.bfr.knime.fsklab.nodes.plot.PythonPlotter;
 import de.bund.bfr.knime.fsklab.v1_9.FskPortObject;
 import de.bund.bfr.knime.fsklab.v1_9.FskSimulation;
@@ -20,7 +21,18 @@ public class PythonScriptHandler extends ScriptHandler {
   // controller that communicates with Python Installation
   PythonKernel controller;
 
-  // Currently only PythonPlotter is assigned as it is the only available for Python
+  
+  public PythonScriptHandler(PythonVersionOption version) throws IOException {
+    
+    PythonKernelOptions m_kernelOptions = new PythonKernelOptions();
+    m_kernelOptions.setPythonVersionOption(version);
+    controller = new PythonKernel(m_kernelOptions);
+    
+    // Currently only PythonPlotter is assigned as it is the only available for Python
+    this.plotter = new PythonPlotter(controller);
+  }
+
+  // if no version is given in the model metadata, use the KNIME preference setting
   public PythonScriptHandler() throws IOException {
     // automatically receive information about used Python Version (2.7 or 3.x)
     PythonKernelOptions m_kernelOptions = new PythonKernelOptions();
@@ -28,7 +40,7 @@ public class PythonScriptHandler extends ScriptHandler {
     
     this.plotter = new PythonPlotter(controller);
   }
-
+  
   @Override
   public void convertToKnimeDataTable(FskPortObject fskObj, ExecutionContext exec) throws Exception {
 

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import org.knime.core.node.ExecutionContext;
 import org.knime.core.node.NodeLogger;
+import org.knime.python2.kernel.PythonKernelOptions.PythonVersionOption;
 import de.bund.bfr.knime.fsklab.nodes.environment.GeneratedResourceFiles;
 import de.bund.bfr.knime.fsklab.nodes.plot.ModelPlotter;
 import de.bund.bfr.knime.fsklab.v1_9.FskPortObject;
@@ -152,7 +153,15 @@ public abstract class ScriptHandler implements AutoCloseable {
       if (type.startsWith("r")) {
         handler = new RScriptHandler(packages);
       } else if (type.startsWith("py")) {
-        handler = new PythonScriptHandler();
+        // check for the python version
+        if(type.startsWith("python 2")) {
+          handler = new PythonScriptHandler(PythonVersionOption.PYTHON2);
+        }else if(type.startsWith("python 3")){
+          handler = new PythonScriptHandler(PythonVersionOption.PYTHON3);  
+        }else {
+          handler = new PythonScriptHandler(); // use version from KNIME preference page
+        }
+        
       } else {
         handler = new RScriptHandler();
       }


### PR DESCRIPTION
#112 (modelrepository): the python interpreter (version2 or version3) is
now picked by using the information from the metadata (language written
in)