### PR TITLE
#632 wrong simulation in SimulationConfigurator JS View

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/simulator/JSSimulatorNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/simulator/JSSimulatorNodeModel.java
@@ -113,6 +113,7 @@ class JSSimulatorNodeModel
         final List<Parameter> parameters = SwaggerUtil.getParameter(port.modelMetadata);
         val.simulations = port.simulations.stream().map(it -> toJSSimulation(it, parameters))
             .collect(Collectors.toList());
+        val.selectedSimulationIndex = port.selectedSimulationIndex;
       }
     }
 


### PR DESCRIPTION
selected simulation was alway default when the Simulationation
Configurator JS View was opened after loading the workflow, now it shows
the corect simulation