### PR TITLE
Fix packages installation on Mac

### DIFF
--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
@@ -145,7 +145,7 @@ public class LibRegistry {
       throw new NoInternetException(packages);
     }
     
-    if (Platform.isLinux()) {
+    if (Platform.isLinux() || Platform.isMac()) {
       // Install missing packages
       controller.addPackagePath(installPath);
       


### PR DESCRIPTION
The packages are installed on Mac like on Linux, by skipping minCRAN and using install.packages to the .fsk/library folder.