### PR TITLE
added #674, #112 and #141 for target platform 3 final release

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/PythonScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/PythonScriptHandler.java
@@ -8,6 +8,7 @@ import org.knime.core.node.NodeLogger;
 import org.knime.core.util.FileUtil;
 import org.knime.python2.kernel.PythonKernel;
 import org.knime.python2.kernel.PythonKernelOptions;
+import org.knime.python2.kernel.PythonKernelOptions.PythonVersionOption;
 import de.bund.bfr.knime.fsklab.nodes.plot.PythonPlotter;
 import de.bund.bfr.knime.fsklab.v1_9.FskPortObject;
 import de.bund.bfr.knime.fsklab.v1_9.FskSimulation;
@@ -21,15 +22,22 @@ public class PythonScriptHandler extends ScriptHandler {
   PythonKernel controller;
 
   
-  public PythonScriptHandler() throws IOException {
-    
+  public PythonScriptHandler(PythonVersionOption version) throws IOException {
+
     PythonKernelOptions m_kernelOptions = new PythonKernelOptions();
-    controller = new PythonKernel(m_kernelOptions);
+    if (version != null) {
+      m_kernelOptions.setPythonVersionOption(version);
+    }
     
+    controller = new PythonKernel(m_kernelOptions);
+
     // Currently only PythonPlotter is assigned as it is the only available for Python
     this.plotter = new PythonPlotter(controller);
   }
-
+  // if no version is given in the model metadata, use the KNIME preference setting
+  public PythonScriptHandler() throws IOException {
+    this(null);
+  }
 
   @Override
   public void convertToKnimeDataTable(FskPortObject fskObj, ExecutionContext exec) throws Exception {

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import org.knime.core.node.ExecutionContext;
 import org.knime.core.node.NodeLogger;
 import org.knime.core.util.FileUtil;
+import org.knime.python2.kernel.PythonKernelOptions.PythonVersionOption;
 import de.bund.bfr.knime.fsklab.nodes.plot.ModelPlotter;
 import de.bund.bfr.knime.fsklab.v1_9.FskPortObject;
 import de.bund.bfr.knime.fsklab.v1_9.FskSimulation;
@@ -156,7 +157,13 @@ public abstract class ScriptHandler implements AutoCloseable {
       if (type.startsWith("r")) {
         handler = new RScriptHandler(packages);
       } else if (type.startsWith("py")) {
-        handler = new PythonScriptHandler();
+        if(type.startsWith("python 2")) {
+          handler = new PythonScriptHandler(PythonVersionOption.PYTHON2);
+        }else if(type.startsWith("python 3")){
+          handler = new PythonScriptHandler(PythonVersionOption.PYTHON3);  
+        }else {
+          handler = new PythonScriptHandler(); // use version from KNIME preference page
+        }
       } else {
         handler = new RScriptHandler();
       }

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
@@ -145,7 +145,7 @@ public class LibRegistry {
       throw new NoInternetException(packages);
     }
     
-    if (Platform.isLinux()) {
+    if (Platform.isLinux() || Platform.isMac()) {
       // Install missing packages
       controller.addPackagePath(installPath);
       

--- a/de.bund.bfr.knime.update/category.xml
+++ b/de.bund.bfr.knime.update/category.xml
@@ -6,9 +6,6 @@
    <feature url="features/de.bund.bfr.knime.pmm.feature_1.2.1.qualifier.jar" id="de.bund.bfr.knime.pmm.feature" version="1.2.2.qualifier">
       <category name="FSK-Lab"/>
    </feature>
-   <feature url="features/de.bund.bfr.knime.fsklab.legacy.feature_1.0.0.qualifier.jar" id="de.bund.bfr.knime.fsklab.legacy.feature" version="1.0.0.qualifier">
-      <category name="FSK-Lab"/>
-   </feature>
    <feature url="features/de.bund.bfr.knime.r.x64.feature_3.4.4.jar" id="de.bund.bfr.knime.r.x64.feature" version="3.4.4">
       <category name="FSK-Lab"/>
    </feature>

--- a/features/de.bund.bfr.knime.fsklab.feature/feature.xml
+++ b/features/de.bund.bfr.knime.fsklab.feature/feature.xml
@@ -194,5 +194,10 @@ along with this program.  If not, see &amp;quot;http://www.gnu.org/licenses/&amp
          download-size="0"
          install-size="0"
          version="0.0.0"/>
-
+<plugin
+         id="de.bund.bfr.knime.fsklab.deprecatednodes"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 </feature>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -13,7 +13,6 @@
 
     <modules>
         <module>de.bund.bfr.knime.fsklab.feature</module>
-        <module>de.bund.bfr.knime.fsklab.legacy.feature</module>
         <module>de.bund.bfr.knime.internal.feature</module>
         <module>de.bund.bfr.knime.pmm.feature</module>
         <module>de.bund.bfr.knime.r.x64.feature</module>


### PR DESCRIPTION
#674: mac support
#114: python auto picker (target 3)
#141: deprecated nodes no longer separate feature