### PR TITLE
R workspace not available after reading FSKX file

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/writer/WriterNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/writer/WriterNodeModel.java
@@ -272,6 +272,11 @@ class WriterNodeModel extends NoInternalsModel {
       writeFSKObject(sfskObj, archive,
           filePrefix + normalizeName(sfskObj) + System.getProperty("file.separator"), URIS);
     }
+    
+    // Adds R workspace file
+    if (fskObj.getWorkspace() != null) {
+      addWorkspace(archive, fskObj.getWorkspace(), filePrefix);
+    }
 
     // Adds model metadata of combined model
     addMetaData(archive, fskObj.modelMetadata, filePrefix + "metaData.json");


### PR DESCRIPTION
The reader and writer nodes were not supporting the R workspace for the
joined models (they did for individual models).

Test workflow: [689_missing_RData.zip](https://github.com/SiLeBAT/FSK-Lab/files/5327205/689_missing_RData.zip)
