### PR TITLE
Add POST method to joinMetadata (empty generic model for now)

### DIFF
--- a/de.bund.bfr.knime.fsklab.service/src/de/bund/bfr/knime/fsklab/service/FskService.java
+++ b/de.bund.bfr.knime.fsklab.service/src/de/bund/bfr/knime/fsklab/service/FskService.java
@@ -126,7 +126,7 @@ public class FskService implements Runnable {
       return;
     }
 
-    port(9999);
+    port(0);
 
     // Enable CORS
     options("/*", (request, response) -> {

--- a/de.bund.bfr.knime.fsklab.service/src/de/bund/bfr/knime/fsklab/service/FskService.java
+++ b/de.bund.bfr.knime.fsklab.service/src/de/bund/bfr/knime/fsklab/service/FskService.java
@@ -3,6 +3,7 @@ package de.bund.bfr.knime.fsklab.service;
 import static spark.Spark.awaitInitialization;
 import static spark.Spark.before;
 import static spark.Spark.get;
+import static spark.Spark.post;
 import static spark.Spark.options;
 import static spark.Spark.port;
 import java.io.File;
@@ -125,7 +126,7 @@ public class FskService implements Runnable {
       return;
     }
 
-    port(0);
+    port(9999);
 
     // Enable CORS
     options("/*", (request, response) -> {
@@ -179,6 +180,17 @@ public class FskService implements Runnable {
       res.status(200);
 
       return convertMetadata(inputMetadata, req.params(":targetModelClass"));
+    }, jsonTransformer);
+    
+    post("joinMetadata", (req, res) -> {
+      // String body = req.body();
+      // Do nothing with body yet
+      // The body keeps two JSON models in an array.
+      
+      res.type("application/json");
+      res.status(200);
+      
+      return new GenericModel();
     }, jsonTransformer);
 
     // After initializing the service, get the randomly picked port by Spark.


### PR DESCRIPTION
Sorry for the lack of tests. In the state of the service now, it is really hard to pull it out of KNIME to test it. (Need to work on it).

This join method takes the metadata of two models as an array in the body of the request and returns an empty generic model (for now). This endpoint will be finished with a joining algorithm that will return a filled generic model. This can be tested when KNIME is running with the following Java code:

```java
  public static void main(String[] args) throws IOException {
    
    ObjectMapper mapper = new ObjectMapper();
    
    GenericModel exampleModel = new GenericModel();
    GenericModel secondExample = new GenericModel();
    Model[] models = { exampleModel, secondExample };
    
    URL url = new URL("http://localhost:9999/joinMetadata");
    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
    conn.setRequestMethod("POST");
    conn.setRequestProperty("Content-Type", "application/json; utf-8");
    conn.setRequestProperty("Accept", "application/json");
    conn.setDoOutput(true);
    
    try (OutputStream outputStream = conn.getOutputStream()) {
      mapper.writeValue(outputStream, models);
    }
    
    // Response
    int status = conn.getResponseCode();
    
    conn.disconnect();
  }
```

Since the port number in KNIME is picked randomly we need to change it manually in FskService:199 which now has port 0. With this we fix the port and we can use it in the test.