### PR TITLE
String literals should not be duplicated (java:S1192)

### DIFF
--- a/de.bund.bfr.knime.fsklab.service/src/de/bund/bfr/knime/fsklab/service/FskService.java
+++ b/de.bund.bfr.knime.fsklab.service/src/de/bund/bfr/knime/fsklab/service/FskService.java
@@ -105,6 +105,8 @@ import spark.ResponseTransformer;
 
 public class FskService implements Runnable {
 
+  private static final String MIME_JSON = "application/json";
+  
   private static final NodeLogger LOGGER = NodeLogger.getLogger(FskService.class);
 
   private static final JsonTransformer jsonTransformer = new JsonTransformer();
@@ -147,7 +149,7 @@ public class FskService implements Runnable {
 
     get("getById/:vocabulary/:id", (req, res) -> {
       try (Connection connection = DriverManager.getConnection("jdbc:h2:~/.fsk/vocabularies")) {
-        res.type("application/json");
+        res.type(MIME_JSON);
         BasicRepository<?> repository = getRepository(req.params(":vocabulary"), connection);
         int id = Integer.parseInt(req.params(":id"));
         return repository.getById(id);
@@ -156,7 +158,7 @@ public class FskService implements Runnable {
 
     get("/getAll/:vocabulary", (req, res) -> {
       try (Connection connection = DriverManager.getConnection("jdbc:h2:~/.fsk/vocabularies")) {
-        res.type("application/json");
+        res.type(MIME_JSON);
         BasicRepository<?> repository = getRepository(req.params(":vocabulary"), connection);
         return repository.getAll();
       }
@@ -164,7 +166,7 @@ public class FskService implements Runnable {
 
     get("/getAllNames/:vocabulary", (req, res) -> {
       try (Connection connection = DriverManager.getConnection("jdbc:h2:~/.fsk/vocabularies")) {
-        res.type("application/json");
+        res.type(MIME_JSON);
         BasicRepository<?> repository = getRepository(req.params(":vocabulary"), connection);
         return repository.getAllNames();
       }
@@ -175,7 +177,7 @@ public class FskService implements Runnable {
       String inputMetadata = req.body();
       // System.out.println(inputMetadata);
 
-      res.type("application/json");
+      res.type(MIME_JSON);
       res.status(200);
 
       return convertMetadata(inputMetadata, req.params(":targetModelClass"));


### PR DESCRIPTION
The string literal "application/json" for the content type of many
responses is replaced with a constant (MIME_TYPE) in a single place.