### PR TITLE
Databases should be password-protected (java:S2115)

### DIFF
--- a/de.bund.bfr.knime.fsklab.service/src/de/bund/bfr/knime/fsklab/service/FskService.java
+++ b/de.bund.bfr.knime.fsklab.service/src/de/bund/bfr/knime/fsklab/service/FskService.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -146,7 +147,7 @@ public class FskService implements Runnable {
     before((request, response) -> response.header("Access-Control-Allow-Origin", "*"));
 
     get("getById/:vocabulary/:id", (req, res) -> {
-      try (Connection connection = DriverManager.getConnection("jdbc:h2:~/.fsk/vocabularies")) {
+      try (Connection connection = DriverManager.getConnection("jdbc:h2:~/.fsk/vocabularies", "fsk", "fsk")) {
         res.type("application/json");
         BasicRepository<?> repository = getRepository(req.params(":vocabulary"), connection);
         int id = Integer.parseInt(req.params(":id"));
@@ -155,7 +156,7 @@ public class FskService implements Runnable {
     }, jsonTransformer);
 
     get("/getAll/:vocabulary", (req, res) -> {
-      try (Connection connection = DriverManager.getConnection("jdbc:h2:~/.fsk/vocabularies")) {
+      try (Connection connection = DriverManager.getConnection("jdbc:h2:~/.fsk/vocabularies", "fsk", "fsk")) {
         res.type("application/json");
         BasicRepository<?> repository = getRepository(req.params(":vocabulary"), connection);
         return repository.getAll();
@@ -163,7 +164,7 @@ public class FskService implements Runnable {
     }, jsonTransformer);
 
     get("/getAllNames/:vocabulary", (req, res) -> {
-      try (Connection connection = DriverManager.getConnection("jdbc:h2:~/.fsk/vocabularies")) {
+      try (Connection connection = DriverManager.getConnection("jdbc:h2:~/.fsk/vocabularies", "fsk", "fsk")) {
         res.type("application/json");
         BasicRepository<?> repository = getRepository(req.params(":vocabulary"), connection);
         return repository.getAllNames();
@@ -397,6 +398,8 @@ public class FskService implements Runnable {
     fastImportProperties.put("CACHE_SIZE", 65536);
     fastImportProperties.put("LOCK_MODE", 0);
     fastImportProperties.put("UNDO_LOG", 0);
+    fastImportProperties.put("user", "fsk");
+    fastImportProperties.put("password", "fsk");
 
     Class.forName("org.h2.Driver");
     DeleteDbFiles.execute("~/.fsk", "vocabularies", true); // Delete DB if it exists
@@ -435,7 +438,7 @@ public class FskService implements Runnable {
         Statement statement = initialConnection.createStatement();
 
         File file = getResource(bundle, "data/initialdata/" + filename);
-        for (String line : FileUtils.readLines(file, "UTF-8")) {
+        for (String line : FileUtils.readLines(file, StandardCharsets.UTF_8)) {
           statement.execute(line);
         }
       } catch (IOException | SQLException | URISyntaxException e) {


### PR DESCRIPTION
Add user and password to the RAKIP vocabularies database.

## java:S2115
Databases should always be password protected. The use of a database
connection with an empty password is a clear indication of a database
that is not protected.
This rule flags database connections with empty passwords.