### PR TITLE
Finish conversion algorithm

### DIFF
--- a/de.bund.bfr.knime.fsklab.metadata.model.tests/src/metadata/ConversionUtilsTest.java
+++ b/de.bund.bfr.knime.fsklab.metadata.model.tests/src/metadata/ConversionUtilsTest.java
@@ -1,29 +1,166 @@
 package metadata;
 
-import static org.junit.Assert.assertEquals;
-
+import static org.junit.Assert.*;
 import java.io.File;
-
+import java.io.IOException;
+import org.junit.BeforeClass;
 import org.junit.Test;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+@SuppressWarnings("static-method")
 public class ConversionUtilsTest {
+  
+  private static ObjectMapper MAPPER;
+  
+  @BeforeClass
+  public static void doSetup() {
+    MAPPER = new ObjectMapper();
+  }
 
-  @SuppressWarnings("unchecked")
   @Test
-  public void testConversion() throws Exception {
+  public void testConvertModel_genericModel_toGenericModel() throws Exception {
     ConversionUtils utils = new ConversionUtils();
 
-    ObjectMapper mapper = new ObjectMapper();
+    // Example data
+    JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
+
+    // It passes if no exceptions are thrown
+    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "genericModel");
+    
+    assertEquals("genericModel", convertedMetadata.get("modelType").asText());
+  }
+  
+  @Test
+  public void testConvertModel_genericModel_toDataModel() throws JsonProcessingException, IOException {
+    ConversionUtils utils = new ConversionUtils();
 
     // Example data
-    JsonNode inputMetadata = mapper.readTree(new File("files/metadata.json"));
+    JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
+
+    // It passes if no exceptions are thrown
+    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "dataModel");
+    
+    assertEquals("dataModel", convertedMetadata.get("modelType").asText());
+  }
+  
+  
+  @Test
+  public void testConvertModel_genericModel_toPredictiveModel() throws JsonProcessingException, IOException {
+    ConversionUtils utils = new ConversionUtils();
+
+    // Example data
+    JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
+
+    // It passes if no exceptions are thrown
+    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "predictiveModel");
+    
+    assertEquals("predictiveModel", convertedMetadata.get("modelType").asText());
+  }
+  
+  @Test
+  public void testConvertModel_genericModel_toOtherModel() throws JsonProcessingException, IOException {
+    ConversionUtils utils = new ConversionUtils();
+
+    // Example data
+    JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
+
+    // It passes if no exceptions are thrown
+    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "otherModel");
+    
+    assertEquals("otherModel", convertedMetadata.get("modelType").asText());
+  }
+  
+  @Test
+  public void testConvertModel_genericModel_toExposureModel() throws JsonProcessingException, IOException {
+    ConversionUtils utils = new ConversionUtils();
+
+    // Example data
+    JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
+
+    // It passes if no exceptions are thrown
+    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "exposureModel");
+    
+    assertEquals("exposureModel", convertedMetadata.get("modelType").asText());
+  }
+  
+  @Test
+  public void testConvertModel_genericModel_toToxicologicalModel() throws JsonProcessingException, IOException {
+    ConversionUtils utils = new ConversionUtils();
+
+    // Example data
+    JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
+
+    // It passes if no exceptions are thrown
+    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "toxicologicalModel");
+    
+    assertEquals("toxicologicalModel", convertedMetadata.get("modelType").asText());
+  }
+  
+  
+  @Test
+  public void testConvertModel_genericModel_toProcessModel() throws JsonProcessingException, IOException {
+    ConversionUtils utils = new ConversionUtils();
+
+    // Example data
+    JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
 
     // It passes if no exceptions are thrown
     JsonNode convertedMetadata = utils.convertModel(inputMetadata, "processModel");
     
     assertEquals("processModel", convertedMetadata.get("modelType").asText());
+  }
+  
+  @Test
+  public void testConvertModel_genericModel_toConsumptionModel() throws JsonProcessingException, IOException {
+    ConversionUtils utils = new ConversionUtils();
+
+    // Example data
+    JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
+
+    // It passes if no exceptions are thrown
+    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "consumptionModel");
+    
+    assertEquals("consumptionModel", convertedMetadata.get("modelType").asText());
+  }
+  
+  @Test
+  public void testConvertModel_genericModel_toHealthModel() throws JsonProcessingException, IOException {
+    ConversionUtils utils = new ConversionUtils();
+
+    // Example data
+    JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
+
+    // It passes if no exceptions are thrown
+    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "healthModel");
+    
+    assertEquals("healthModel", convertedMetadata.get("modelType").asText());
+  }
+  
+  @Test
+  public void testConvertModel_genericModel_toRiskModel() throws JsonProcessingException, IOException {
+    ConversionUtils utils = new ConversionUtils();
+
+    // Example data
+    JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
+
+    // It passes if no exceptions are thrown
+    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "riskModel");
+    
+    assertEquals("riskModel", convertedMetadata.get("modelType").asText());
+  }
+  
+  @Test
+  public void testConvertModel_genericModel_toQraModel() throws JsonProcessingException, IOException {
+    ConversionUtils utils = new ConversionUtils();
+
+    // Example data
+    JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
+
+    // It passes if no exceptions are thrown
+    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "qraModel");
+    
+    assertEquals("qraModel", convertedMetadata.get("modelType").asText());
   }
 }


### PR DESCRIPTION
This finishes work of https://github.com/SiLeBAT/FSK-Lab/pull/715. It adds full support for nested objects and arrays with recursion. Items in arrays are also check for compatibility and if possible are converted to the target schema.

The unittest has been extended to convert the example generic model to all the other model classes. Like before, the endpoint can be tested with the Java snippet:

```java
public class ConversionTest {

	public static void main(String[] args) throws IOException {

		ObjectMapper mapper = new ObjectMapper();

		URL url = new URL("http://localhost:9999/convertMetadata/processModel");
		HttpURLConnection conn = (HttpURLConnection) url.openConnection();
		conn.setRequestMethod("POST");
		conn.setRequestProperty("Content-Type", "application/json; utf-8");
		conn.setRequestProperty("Accept", "application/json");
		conn.setDoOutput(true);

		GenericModel exampleModel = new GenericModel()
				.generalInformation(new GenericModelGeneralInformation().name("Toy model"));
		exampleModel.setModelType("genericModel");
		try (OutputStream outputStream = conn.getOutputStream()) {
			mapper.writeValue(outputStream, exampleModel);
		}

		// Response
		int status = conn.getResponseCode();

		conn.disconnect();
	}
}
```