### PR TITLE
Joining algorithm fixes

### DIFF
--- a/de.bund.bfr.knime.fsklab.metadata.model/src/metadata/ConversionUtils.java
+++ b/de.bund.bfr.knime.fsklab.metadata.model/src/metadata/ConversionUtils.java
@@ -16,12 +16,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
 
 
 @SuppressWarnings("unchecked")
 public class ConversionUtils {
 
-	private static final ObjectMapper MAPPER = new ObjectMapper();
+	private static final ObjectMapper MAPPER = new ObjectMapper()
+			.registerModule(new ThreeTenModule());
 
 	/** Definitions in Swagger YAML. */
 	private final Map<String, Object> definitions;

--- a/de.bund.bfr.knime.fsklab.metadata.model/src/metadata/ConversionUtils.java
+++ b/de.bund.bfr.knime.fsklab.metadata.model/src/metadata/ConversionUtils.java
@@ -237,11 +237,18 @@ public class ConversionUtils {
 			if (targetProp.containsKey(TYPE)) {
 				String targetPropertyType = (String) targetProp.get(TYPE);
 				if (targetPropertyType.equals("string")) {
-
-					String newValue = combineStringProperties(key, propA, metadataA, propB, metadataB);
-					if (!newValue.isEmpty()) {
-						node.put(key, newValue);
+					if (targetProp.containsKey("format") && targetProp.get("format").equals("date")) {
+						JsonNode newValue = combineDateProperties(key, propA, metadataA, propB, metadataB);
+						if (newValue != null) {
+							node.set(key, newValue);
+						}
+					} else {
+						String newValue = combineStringProperties(key, propA, metadataA, propB, metadataB);
+						if (!newValue.isEmpty()) {
+							node.put(key, newValue);
+						}
 					}
+
 				} else if (targetPropertyType.equals("array")) {
 					ArrayNode joinedArray = MAPPER.createArrayNode();
 
@@ -306,6 +313,22 @@ public class ConversionUtils {
 		} else {
 			return "";
 		}
+	}
+	
+	private static JsonNode combineDateProperties(String key, Map<String, Object> propA, JsonNode metadataA,
+			Map<String, Object> propB, JsonNode metadataB) {
+		
+		if (!propA.isEmpty() && ((String) propA.get(TYPE)).equals("string") && ((String) propA.get("format")).equals("date")
+				&& metadataA.has(key) && !metadataA.get(key).isNull()) {
+			return metadataA.get(key);
+		}
+		
+		if (!propB.isEmpty() && ((String) propB.get(TYPE)).equals("string") && ((String) propB.get("format")).equals("date")
+				&& metadataB.has(key) && !metadataB.get(key).isNull()) {
+			return metadataA.get(key);
+		}
+		
+		return null;
 	}
 
 	private Map<String, Object> getProperties(Map<String, Object> property) {

--- a/de.bund.bfr.knime.fsklab.service/META-INF/MANIFEST.MF
+++ b/de.bund.bfr.knime.fsklab.service/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.8.9",
  com.fasterxml.jackson.core.jackson-core;bundle-version="2.8.9",
  com.fasterxml.jackson.core.jackson-databind;bundle-version="2.8.9",
- com.google.gson;bundle-version="2.8.1",
  de.bund.bfr.knime.fsklab.metadata.model;bundle-version="0.1.0",
  javax.servlet;bundle-version="3.1.0",
  org.eclipse.jetty.http;bundle-version="9.4.8",

--- a/de.bund.bfr.knime.fsklab.service/META-INF/MANIFEST.MF
+++ b/de.bund.bfr.knime.fsklab.service/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-SymbolicName: de.bund.bfr.knime.fsklab.service
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: de.bund.bfr.knime.fsklab.service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: com.fasterxml.jackson.core.jackson-core;bundle-version="2.8.9",
+Require-Bundle: com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.8.9",
+ com.fasterxml.jackson.core.jackson-core;bundle-version="2.8.9",
  com.fasterxml.jackson.core.jackson-databind;bundle-version="2.8.9",
  com.google.gson;bundle-version="2.8.1",
  de.bund.bfr.knime.fsklab.metadata.model;bundle-version="0.1.0",


### PR DESCRIPTION
Joining algorithm returns a GenericModel instead of JsonNode and several issues related to null and empty properties are fixed.

Example:
```java
  public static void main(String[] args) throws IOException {
	    
	    ObjectMapper mapper = new ObjectMapper().registerModule(new ThreeTenModule());
	    
	    JsonNode exampleModel = mapper.readTree(new File("files/marcel/nautaCPM.json"));
	    JsonNode exampleModel2 = mapper.readTree(new File("files/marcel/medChallDRM.json"));
	    JsonNode[] models = { exampleModel, exampleModel2 };
	    
	    URL url = new URL("http://localhost:9999/joinMetadata");
	    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
	    conn.setRequestMethod("POST");
	    conn.setRequestProperty("Content-Type", "application/json; utf-8");
	    conn.setRequestProperty("Accept", "application/json");
	    conn.setDoOutput(true);
	    
	    try (OutputStream outputStream = conn.getOutputStream()) {
	      mapper.writeValue(outputStream, models);
	    }
	    
	    // Response
	    int status = conn.getResponseCode();
	    
	    try (InputStream stream = conn.getInputStream()) {
//	    	JsonNode output = mapper.readTree(stream);
	    	GenericModel output = mapper.readValue(stream, GenericModel.class);
	    	System.out.println(output);
	    }
	    
	    conn.disconnect();
	  }
```