### PR TITLE
Change conversion and joining algorithms to return POJOs

### DIFF
--- a/de.bund.bfr.knime.fsklab.metadata.model.tests/src/metadata/ConversionUtilsTest.java
+++ b/de.bund.bfr.knime.fsklab.metadata.model.tests/src/metadata/ConversionUtilsTest.java
@@ -1,6 +1,6 @@
 package metadata;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.IOException;
 import org.junit.BeforeClass;
@@ -8,6 +8,9 @@ import org.junit.Test;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
+import de.bund.bfr.metadata.swagger.Model;
+import metadata.ConversionUtils.ModelClass;
 
 @SuppressWarnings("static-method")
 public class ConversionUtilsTest {
@@ -16,7 +19,7 @@ public class ConversionUtilsTest {
   
   @BeforeClass
   public static void doSetup() {
-    MAPPER = new ObjectMapper();
+    MAPPER = new ObjectMapper().registerModule(new ThreeTenModule());
   }
 
   @Test
@@ -27,9 +30,8 @@ public class ConversionUtilsTest {
     JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
 
     // It passes if no exceptions are thrown
-    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "genericModel");
-    
-    assertEquals("genericModel", convertedMetadata.get("modelType").asText());
+    Model convertedModel = utils.convertModel(inputMetadata, ModelClass.genericModel);
+    assertEquals("genericModel", convertedModel.getModelType());
   }
   
   @Test
@@ -40,11 +42,9 @@ public class ConversionUtilsTest {
     JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
 
     // It passes if no exceptions are thrown
-    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "dataModel");
-    
-    assertEquals("dataModel", convertedMetadata.get("modelType").asText());
+    Model convertedModel = utils.convertModel(inputMetadata, ModelClass.dataModel);
+    assertEquals("dataModel", convertedModel.getModelType());
   }
-  
   
   @Test
   public void testConvertModel_genericModel_toPredictiveModel() throws JsonProcessingException, IOException {
@@ -54,9 +54,8 @@ public class ConversionUtilsTest {
     JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
 
     // It passes if no exceptions are thrown
-    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "predictiveModel");
-    
-    assertEquals("predictiveModel", convertedMetadata.get("modelType").asText());
+    Model convertedModel = utils.convertModel(inputMetadata, ModelClass.predictiveModel);
+    assertEquals("predictiveModel", convertedModel.getModelType());
   }
   
   @Test
@@ -67,9 +66,8 @@ public class ConversionUtilsTest {
     JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
 
     // It passes if no exceptions are thrown
-    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "otherModel");
-    
-    assertEquals("otherModel", convertedMetadata.get("modelType").asText());
+    Model convertedModel = utils.convertModel(inputMetadata, ModelClass.otherModel);
+    assertEquals("otherModel", convertedModel.getModelType());
   }
   
   @Test
@@ -80,9 +78,8 @@ public class ConversionUtilsTest {
     JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
 
     // It passes if no exceptions are thrown
-    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "exposureModel");
-    
-    assertEquals("exposureModel", convertedMetadata.get("modelType").asText());
+    Model convertedModel = utils.convertModel(inputMetadata, ModelClass.exposureModel);
+    assertEquals("exposureModel", convertedModel.getModelType());
   }
   
   @Test
@@ -93,11 +90,9 @@ public class ConversionUtilsTest {
     JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
 
     // It passes if no exceptions are thrown
-    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "toxicologicalModel");
-    
-    assertEquals("toxicologicalModel", convertedMetadata.get("modelType").asText());
+    Model convertedModel = utils.convertModel(inputMetadata, ModelClass.toxicologicalModel);
+    assertEquals("toxicologicalModel", convertedModel.getModelType());
   }
-  
   
   @Test
   public void testConvertModel_genericModel_toProcessModel() throws JsonProcessingException, IOException {
@@ -107,9 +102,8 @@ public class ConversionUtilsTest {
     JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
 
     // It passes if no exceptions are thrown
-    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "processModel");
-    
-    assertEquals("processModel", convertedMetadata.get("modelType").asText());
+    Model convertedModel = utils.convertModel(inputMetadata, ModelClass.processModel);
+    assertEquals("processModel", convertedModel.getModelType());
   }
   
   @Test
@@ -120,9 +114,8 @@ public class ConversionUtilsTest {
     JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
 
     // It passes if no exceptions are thrown
-    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "consumptionModel");
-    
-    assertEquals("consumptionModel", convertedMetadata.get("modelType").asText());
+    Model convertedModel = utils.convertModel(inputMetadata, ModelClass.consumptionModel);
+    assertEquals("consumptionModel", convertedModel.getModelType());
   }
   
   @Test
@@ -133,9 +126,8 @@ public class ConversionUtilsTest {
     JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
 
     // It passes if no exceptions are thrown
-    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "healthModel");
-    
-    assertEquals("healthModel", convertedMetadata.get("modelType").asText());
+    Model convertedModel = utils.convertModel(inputMetadata, ModelClass.healthModel);
+    assertEquals("healthModel", convertedModel.getModelType());
   }
   
   @Test
@@ -146,9 +138,8 @@ public class ConversionUtilsTest {
     JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
 
     // It passes if no exceptions are thrown
-    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "riskModel");
-    
-    assertEquals("riskModel", convertedMetadata.get("modelType").asText());
+    Model convertedModel = utils.convertModel(inputMetadata, ModelClass.riskModel);
+    assertEquals("riskModel", convertedModel.getModelType());
   }
   
   @Test
@@ -159,9 +150,8 @@ public class ConversionUtilsTest {
     JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
 
     // It passes if no exceptions are thrown
-    JsonNode convertedMetadata = utils.convertModel(inputMetadata, "qraModel");
-    
-    assertEquals("qraModel", convertedMetadata.get("modelType").asText());
+    Model convertedModel = utils.convertModel(inputMetadata, ModelClass.qraModel);
+    assertEquals("qraModel", convertedModel.getModelType());
   }
   
   @Test
@@ -172,8 +162,7 @@ public class ConversionUtilsTest {
     JsonNode inputMetadata = MAPPER.readTree(new File("files/metadata.json"));
 
     // It passes if no exceptions are thrown
-    JsonNode joined = utils.joinModels(inputMetadata, inputMetadata, "genericModel");
-    
-    assertEquals("genericModel", joined.get("modelType").asText());
+    Model joined = utils.joinModels(inputMetadata, inputMetadata, ModelClass.genericModel);
+    assertEquals("genericModel", joined.getModelType());
   }
 }

--- a/de.bund.bfr.knime.fsklab.service/src/de/bund/bfr/knime/fsklab/service/FskService.java
+++ b/de.bund.bfr.knime.fsklab.service/src/de/bund/bfr/knime/fsklab/service/FskService.java
@@ -6,7 +6,6 @@ import static spark.Spark.get;
 import static spark.Spark.options;
 import static spark.Spark.port;
 import static spark.Spark.post;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -20,21 +19,18 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
-
 import org.apache.commons.io.FileUtils;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Platform;
 import org.h2.tools.DeleteDbFiles;
 import org.knime.core.node.NodeLogger;
 import org.osgi.framework.Bundle;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
-
-import de.bund.bfr.metadata.swagger.GenericModel;
+import de.bund.bfr.metadata.swagger.Model;
 import de.bund.bfr.rakip.vocabularies.data.AccreditationProcedureRepository;
 import de.bund.bfr.rakip.vocabularies.data.AvailabilityRepository;
 import de.bund.bfr.rakip.vocabularies.data.BasicProcessRepository;
@@ -77,6 +73,7 @@ import de.bund.bfr.rakip.vocabularies.data.TechnologyTypeRepository;
 import de.bund.bfr.rakip.vocabularies.data.UnitCategoryRepository;
 import de.bund.bfr.rakip.vocabularies.data.UnitRepository;
 import metadata.ConversionUtils;
+import metadata.ConversionUtils.ModelClass;
 import spark.ResponseTransformer;
 
 public class FskService implements Runnable {
@@ -156,9 +153,8 @@ public class FskService implements Runnable {
 
 			try {
 				JsonNode inputMetadata = jsonTransformer.MAPPER.readTree(req.body());
-				String targetClass = req.params("targetModelClass");
-				JsonNode convertedMetadata = utils.convertModel(inputMetadata, targetClass);
-
+				ModelClass targetClass = ModelClass.valueOf(req.params("targetModelClass"));
+				Model convertedMetadata = utils.convertModel(inputMetadata, targetClass);
 				res.status(200);
 				return convertedMetadata;
 			} catch (Exception err) {
@@ -175,9 +171,9 @@ public class FskService implements Runnable {
 				JsonNode models = jsonTransformer.MAPPER.readTree(req.body());
 				JsonNode firstModel = models.get(0);
 				JsonNode secondModel = models.get(1);
-				JsonNode joinedModel = utils.joinModels(firstModel, secondModel, "genericModel");
+				Model joinedModel = utils.joinModels(firstModel, secondModel, ModelClass.genericModel);
 				res.status(200);
-				return jsonTransformer.MAPPER.treeToValue(joinedModel, GenericModel.class);
+				return joinedModel;
 			} catch (Exception err) {
 				res.status(500);
 				return err;


### PR DESCRIPTION
The conversion and joining algorithms return deserialized model metadata instead of a JSON node.