### PR TITLE
copy generated resources to working directory

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/PythonScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/PythonScriptHandler.java
@@ -8,7 +8,6 @@ import org.knime.core.node.NodeLogger;
 import org.knime.core.util.FileUtil;
 import org.knime.python2.kernel.PythonKernel;
 import org.knime.python2.kernel.PythonKernelOptions;
-import org.knime.python2.kernel.PythonKernelOptions.PythonVersionOption;
 import de.bund.bfr.knime.fsklab.nodes.plot.PythonPlotter;
 import de.bund.bfr.knime.fsklab.v1_9.FskPortObject;
 import de.bund.bfr.knime.fsklab.v1_9.FskSimulation;

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/joiner/JoinerNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/joiner/JoinerNodeModel.java
@@ -441,6 +441,7 @@ public final class JoinerNodeModel
     JoinerViewValue viewValue = getViewValue();
     viewValue.joinRelations = nodeSettings.connections;
     viewValue.modelScriptTree = sourceTree;
+    viewValue.modelMetaData = nodeSettings.modelMetaData;
     JoinerViewRepresentation representation = getViewRepresentation();
     if (nodeSettings.firstModelParameters != null) {
       representation.setFirstModelParameters(nodeSettings.firstModelParameters);

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/runner/RunnerNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/runner/RunnerNodeModel.java
@@ -431,6 +431,7 @@ public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjec
 
       for (final String line : output) {
         if (line.startsWith(ScriptExecutor.ERROR_PREFIX)) {
+          LOGGER.error(line);
           throw new RException(line, null);
         }
        
@@ -438,6 +439,7 @@ public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjec
       }
       // error output message for python:
       if (handler instanceof PythonScriptHandler  ) {
+        LOGGER.error(handler.getStdErr());
         throw new Exception(handler.getStdErr(),null);
       }
     }

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/runner/RunnerNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/runner/RunnerNodeModel.java
@@ -21,7 +21,6 @@ package de.bund.bfr.knime.fsklab.v1_9.runner;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -48,6 +47,7 @@ import org.knime.core.node.port.PortType;
 import org.knime.core.node.port.image.ImagePortObject;
 import org.knime.core.node.port.image.ImagePortObjectSpec;
 import org.knime.core.util.FileUtil;
+import de.bund.bfr.knime.fsklab.nodes.PythonScriptHandler;
 import de.bund.bfr.knime.fsklab.nodes.ScriptHandler;
 import de.bund.bfr.knime.fsklab.r.client.IRController.RException;
 import de.bund.bfr.knime.fsklab.r.client.ScriptExecutor;
@@ -433,6 +433,12 @@ public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjec
         if (line.startsWith(ScriptExecutor.ERROR_PREFIX)) {
           throw new RException(line, null);
         }
+       
+        
+      }
+      // error output message for python:
+      if (handler instanceof PythonScriptHandler  ) {
+        throw new Exception(handler.getStdErr(),null);
       }
     }
 


### PR DESCRIPTION
also: added error output for python (it was only implemented for R)
and fixed an issue with loading metadata into Joiner node