### PR TITLE
fixed a bug, where simulation files are read into workingDirectory

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/reader/ReaderNodeUtil.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/reader/ReaderNodeUtil.java
@@ -511,7 +511,7 @@ public class ReaderNodeUtil {
 
       // Get entries of the current model
       List<ArchiveEntry> entries = archive.getEntries().stream()
-          .filter(entry -> entry.getEntityPath().indexOf(pathToResource) == 0)
+          .filter(entry -> entry.getEntityPath().lastIndexOf(pathToResource) == 0)
           .collect(Collectors.toList());
 
       URI textUri = URI.create("http://purl.org/NET/mediatypes/text-xplain");

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/reader/ReaderNodeUtil.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v1_9/reader/ReaderNodeUtil.java
@@ -509,9 +509,10 @@ public class ReaderNodeUtil {
       String pathToResource = ListOfPaths.get(0);
       String readme = "";
 
-      // Get entries of the current model
+      // Get entries of the current model (but ignore files in /simulations/ )
       List<ArchiveEntry> entries = archive.getEntries().stream()
-          .filter(entry -> entry.getEntityPath().lastIndexOf(pathToResource) == 0)
+          .filter(entry -> entry.getEntityPath().indexOf(pathToResource) == 0 
+          && !entry.getEntityPath().startsWith(pathToResource + "simulations" + pathToResource))
           .collect(Collectors.toList());
 
       URI textUri = URI.create("http://purl.org/NET/mediatypes/text-xplain");


### PR DESCRIPTION
In the Reader, simulation (e.g. simulations/defaultsimulation.r) files would be considered part of the
"entries" to be loaded into the workingdirectory (environment). This bug
has the consequence, that the simulation.r (or .py) files end up in the
root folder of the written fskx file.