### PR TITLE
fixed bug where setting the path to .fsk folder is sometimes skipped

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
@@ -63,10 +63,9 @@ public abstract class ScriptHandler implements AutoCloseable {
     exec.setProgress(0.1, "Setting up output capturing");
     setupOutputCapturing(exec);
 
-    // Install needed libraries
-    if (!fskObj.packages.isEmpty()) {
-      installLibs(fskObj, exec, logger);
-    }
+    // Install needed libraries & set path to .fsk folder
+    installLibs(fskObj, exec, logger);
+    
 
     jsonHandler = JsonHandler.createHandler(this, exec);
     jsonHandler.applyJoinRelation(fskObj, joinRelationList, suffix);


### PR DESCRIPTION
this leads to removal of user folder in .libPaths when executing multiple models in a row (combined model execution).

workflow: https://seafile.bfr.berlin/smart-link/5e75119b-f080-4f96-b785-26dcca8e3f3f/

linked to RakipInitiative/ModelRepository#270
