### PR TITLE
removed rounding of double parameters to allow more precision

### DIFF
--- a/de.bund.bfr.knime.js/src/js/app/app.simulation.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.simulation.js
@@ -382,7 +382,7 @@ class APPSimulation {
 							}
 							// add decimals support
 							if ( decimals > 0 ) {
-								$input.attr( 'data-touchspin-decimals', true );
+								$input.attr( 'data-touchspin-decimals', decimals );
 							}
 						}
 						// add step range

--- a/de.bund.bfr.knime.js/src/js/app/app.ui.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.ui.js
@@ -365,6 +365,7 @@ class APPUI {
 				decimals			: 0,
 				initval 			: 0,
 				mousewheel			: true,
+				min					: null,
 				forcestepdivisibility : 'none',
 				step 				: 1
 			};
@@ -396,6 +397,7 @@ class APPUI {
 			if( el.hasAttribute( 'data-touchspin-postfix' ) ) {
 				touchspinDefaults.postfix = $el.data( 'touchspin-postfix' );
 			}
+			_log( touchspinDefaults );
 			// create touchspin
 			$el.TouchSpin( touchspinDefaults );
 		} );
@@ -642,7 +644,6 @@ class APPUI {
 		O._initSelect2();
 		O._initDatepicker();
 		O._initRangeslider();
-		O._initTable();
 		O._initFormValidation();
 	};
 

--- a/de.bund.bfr.knime.js/src/js/app/app.ui.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.ui.js
@@ -365,6 +365,7 @@ class APPUI {
 				decimals			: 0,
 				initval 			: 0,
 				mousewheel			: true,
+				forcestepdivisibility : 'none',
 				step 				: 1
 			};
 


### PR DESCRIPTION
switched forcestepdivisibility from 'round'(default) to 'none' to allow
uncapped precision of double parameters