### PR TITLE
Pass vocabularies with JS repr

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/js-src/de/bund/bfr/knime/fsklab/v2.0/editor/editor.js
+++ b/de.bund.bfr.knime.fsklab.nodes/js-src/de/bund/bfr/knime/fsklab/v2.0/editor/editor.js
@@ -59,6 +59,7 @@ fskeditorjs = function () {
     _rep = representation;
     _val = value;
     window._endpoints.controlledVocabularyEndpoint = _rep.controlledVocabularyURL;
+    window.vocabularies = representation.vocabularies;
     //fskutil = new fskutil();
     extractAndCreateUI(value.modelMetaData);
     

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSViewRepresentation.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSViewRepresentation.java
@@ -18,6 +18,8 @@
  */
 package de.bund.bfr.knime.fsklab.v2_0.editor;
 
+import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import org.knime.core.node.InvalidSettingsException;
 import org.knime.core.node.NodeSettingsRO;
@@ -44,6 +46,7 @@ final class FSKEditorJSViewRepresentation extends JSONViewContent {
   private String controlledVocabularyURL;
   private String modelMetadata;
   private boolean combinedObject;
+  private Map<String, String[]> vocabularies;
   
   public boolean isCombinedObject() {
     return combinedObject;
@@ -80,6 +83,14 @@ final class FSKEditorJSViewRepresentation extends JSONViewContent {
   public void setServicePort(int servicePort) {
     this.servicePort = servicePort;
   }
+  
+  public Map<String, String[]> getVocabularies() {
+    return vocabularies;
+  }
+  
+  public void setVocabularies(Map<String, String[]> vocabularies) {
+    this.vocabularies = vocabularies;
+  }
 
   @Override
   public void saveToNodeSettings(NodeSettingsWO settings) {}
@@ -89,7 +100,7 @@ final class FSKEditorJSViewRepresentation extends JSONViewContent {
 
   @Override
   public int hashCode() {
-    return servicePort;
+    return servicePort + Objects.hash(vocabularies);
   }
 
   @Override
@@ -103,6 +114,17 @@ final class FSKEditorJSViewRepresentation extends JSONViewContent {
     if (obj.getClass() != getClass()) {
       return false;
     }
-    return servicePort == ((FSKEditorJSViewRepresentation)obj).servicePort;
+    
+    FSKEditorJSViewRepresentation other = (FSKEditorJSViewRepresentation) obj;
+    
+    if (servicePort != other.servicePort) {
+      return false;
+    }
+    
+    if (vocabularies != null && other.vocabularies != null && vocabularies.equals(other.vocabularies)) {
+      return false;
+    }
+    
+    return true;
   }
 }

--- a/de.bund.bfr.knime.js/src/js/app/app.editable.mt.InputForm.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.editable.mt.InputForm.js
@@ -158,7 +158,8 @@
                 }
                 // Add autocomplete to input with vocabulary
                 if (vocabulary) {
-                    addControlledVocabulary(O.input, vocabulary, port);
+                    // addControlledVocabulary(O.input, vocabulary, port);
+                    addControlledVocabulary(O.input, vocabulary);
                 }
                 O.input.on( "blur", () => {O.validate(O.value)} );
                 // create validation container

--- a/de.bund.bfr.knime.js/src/js/app/app.editable.mt.SelectForm.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.editable.mt.SelectForm.js
@@ -66,32 +66,36 @@
                             .appendTo( $field );
             O.input.val(value);
             // Add options from vocabulary. The option matching value is selected.
-            if(window._endpoints.controlledVocabularyEndpoint){
+            // if(window._endpoints.controlledVocabularyEndpoint){
                 
-                fetch(window._endpoints.controlledVocabularyEndpoint+`${vocabulary}`)
-                    .then(response => response.json())
-                    .then(data => {
-                            O.input.append(data.map(item => `<option>${item}</option>`).join(""));
+            //     fetch(window._endpoints.controlledVocabularyEndpoint+`${vocabulary}`)
+            //         .then(response => response.json())
+            //         .then(data => {
+            //                 O.input.append(data.map(item => `<option>${item}</option>`).join(""));
                         
-                }).catch(error => {
-                    if(port >= 0){
-                        fetch(`http://localhost:${port}/getAllNames/${vocabulary}`)
-                            .then(response => response.json())
-                            .then(data => {
-                                    O.input.append(data.map(item => `<option>${item}</option>`).join(""));
+            //     }).catch(error => {
+            //         if(port >= 0){
+            //             fetch(`http://localhost:${port}/getAllNames/${vocabulary}`)
+            //                 .then(response => response.json())
+            //                 .then(data => {
+            //                         O.input.append(data.map(item => `<option>${item}</option>`).join(""));
                                 
-                        });
-                    }
-                });
+            //             });
+            //         }
+            //     });
                 
-            }
-            else if(port >= 0){
-                fetch(`http://localhost:${port}/getAllNames/${vocabulary}`)
-                    .then(response => response.json())
-                    .then(data => {
-                            O.input.append(data.map(item => `<option>${item}</option>`).join(""));
+            // }
+            // else if(port >= 0){
+            //     fetch(`http://localhost:${port}/getAllNames/${vocabulary}`)
+            //         .then(response => response.json())
+            //         .then(data => {
+            //                 O.input.append(data.map(item => `<option>${item}</option>`).join(""));
                         
-                    });
+            //         });
+            // }
+            if (window.vocabularies[vocabulary]) {
+                let html = window.vocabularies[vocabulary].map(item => `<option>${item}</option>`).join("");
+                O.input.append(html);
             }
 
             // create validation container

--- a/de.bund.bfr.knime.js/src/js/app/app.utils.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.utils.js
@@ -99,6 +99,22 @@ var addControlledVocabulary = (input, vocabulary, port)  =>   {
 }
 
 /**
+ * Add controlled vocabulary to an input.
+ * @param {Element} input Input element
+ * @param {string} vocabularyName Vocabulary name.
+ */
+var addControlledVocabulary = (input, vocabularyName) => {
+	if (window.vocabularies[vocabularyName]) {
+		$(input).typeahead({
+			source: window.vocabularies[vocabularyName],
+			autoSelect: true,
+			fitToElement: true,
+			showHintOnFocus: true
+		});
+	}
+}
+
+/**
  * Create an horizontal form for a metadata property. Missing values with
  * *null* or *undefined* are replaced with an empty string.
  * 


### PR DESCRIPTION
Pass vocabularies as part of the view representation as a map of string arrays. SelectForm and InputForm are patched in the lib.

@ahmadswaid these changes are needed as the vocabularies will not work on the server. When the editor is opened in WebPortal the JS view tries to access the vocabularies in a localhost url and the client does not have FSK-Lab or the FskService. For this I needed to pass the vocabularies to the view so that they work on the server. Also, it was not working locally, I think because of a connection to a remote url. This is not acceptable because we cannot make a requirement of a permanent connection to use the editor. The editor should be fully functional offline.

Regarding my changes in the library, the problem is that now both InputForm and SelectForm use the vocabularies from the JS view with *window.vocabularies*. This is likely to break the landing page as we do not have this data. This is a complex issue since the data used to be queried to a service. We should update the library to add the vocabularies either from the JS view (editor) or a service (like in the landing page).

