### PR TITLE
fix bug in loading the code mirror instance in server mode

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/js-src/de/bund/bfr/knime/fsklab/v2.0/editor/editor.js
+++ b/de.bund.bfr.knime.fsklab.nodes/js-src/de/bund/bfr/knime/fsklab/v2.0/editor/editor.js
@@ -164,41 +164,28 @@ fskeditorjs = function () {
     $('#modelScriptArea').val(modelscript || _val.modelScript);
     $('#visualizationScriptArea').val(visualization || _val.visualizationScript);
     $('#readmeArea').val(_val.readme);
-    let require_config = {
-      packages: [{
-        name: "codemirror",
-        location: "codemirror/",
-        main: "lib/codemirror"
-      }]
-    };
-
-    knimeService.loadConditionally(
-      ["codemirror", "codemirror/mode/r/r", "codemirror/mode/markdown/markdown"],
-      (arg) => {
-        window.CodeMirror = arg[0];
-        _modelCodeMirror = createCodeMirror("modelScriptArea", "text/x-rsrc");
-        _visualizationCodeMirror = createCodeMirror("visualizationScriptArea", "text/x-rsrc");
-        _readmeCodeMirror = createCodeMirror("readmeArea", "text/x-markdown");
-
-        _modelCodeMirror.on("blur", () => { _modelCodeMirror.focus(); });
-        _visualizationCodeMirror.on("blur", () => { _visualizationCodeMirror.focus(); });
-        _readmeCodeMirror.on("blur", () =>{ _readmeCodeMirror.focus(); });
-      },
-      (err) => console.log("knimeService failed to install " + err),
-      require_config);
-
-    $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-        if(e.currentTarget.text == 'Model'){
-          _modelCodeMirror.refresh(); 
-          _modelCodeMirror.focus();
-        }else if(e.currentTarget.text == 'Visualization'){
-          _visualizationCodeMirror.refresh();
-          _visualizationCodeMirror.focus();
-        }else if(e.currentTarget.text == 'Readme'){
-          _readmeCodeMirror.refresh();
-          _readmeCodeMirror.focus();
-        }
-    });
+    
+     _modelCodeMirror = createCodeMirror("modelScriptArea", "text/x-rsrc");
+     _visualizationCodeMirror = createCodeMirror("visualizationScriptArea", "text/x-rsrc");
+     _readmeCodeMirror = createCodeMirror("readmeArea", "text/x-markdown");
+    
+     _modelCodeMirror.on("blur", () => { _modelCodeMirror.focus(); });
+     _visualizationCodeMirror.on("blur", () => { _visualizationCodeMirror.focus(); });
+     _readmeCodeMirror.on("blur", () => { _readmeCodeMirror.focus(); });
+    
+    
+     $('a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
+         if (e.currentTarget.text == 'Model') {
+             _modelCodeMirror.refresh();
+             _modelCodeMirror.focus();
+         } else if (e.currentTarget.text == 'Visualization') {
+             _visualizationCodeMirror.refresh();
+             _visualizationCodeMirror.focus();
+         } else if (e.currentTarget.text == 'Readme') {
+             _readmeCodeMirror.refresh();
+             _readmeCodeMirror.focus();
+         }
+     });
 
     if(_rep.combinedObject){
         $('[aria-controls="#modelScript"]').hide();
@@ -212,7 +199,7 @@ fskeditorjs = function () {
   // Create a CodeMirror for a given text area
   function createCodeMirror(textAreaId, language) {
 
-    return window.CodeMirror.fromTextArea(document.getElementById(textAreaId),
+    return CodeMirror.fromTextArea(document.getElementById(textAreaId),
       {
         lineNumbers: true,
         lineWrapping: true,

--- a/de.bund.bfr.knime.fsklab.nodes/js-src/de/bund/bfr/knime/fsklab/v2.0/editor/editor.js
+++ b/de.bund.bfr.knime.fsklab.nodes/js-src/de/bund/bfr/knime/fsklab/v2.0/editor/editor.js
@@ -168,11 +168,23 @@ fskeditorjs = function () {
      _modelCodeMirror = createCodeMirror("modelScriptArea", "text/x-rsrc");
      _visualizationCodeMirror = createCodeMirror("visualizationScriptArea", "text/x-rsrc");
      _readmeCodeMirror = createCodeMirror("readmeArea", "text/x-markdown");
-    
-     _modelCodeMirror.on("blur", () => { _modelCodeMirror.focus(); });
-     _visualizationCodeMirror.on("blur", () => { _visualizationCodeMirror.focus(); });
-     _readmeCodeMirror.on("blur", () => { _readmeCodeMirror.focus(); });
-    
+     let doScriptSave = () => { 
+        _metadata = _modalDetails._modelHandler.metaData;
+        doSave(_metadata)
+      };
+      
+     _modelCodeMirror.on("blur", () => { 
+        _modelCodeMirror.focus();
+        doScriptSave();
+      });
+     _visualizationCodeMirror.on("blur", () => { 
+        _visualizationCodeMirror.focus();
+        doScriptSave();
+      });
+     _readmeCodeMirror.on("blur", () => { 
+        _readmeCodeMirror.focus();
+        doScriptSave();
+      });
     
      $('a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
          if (e.currentTarget.text == 'Model') {

--- a/de.bund.bfr.knime.js/js-lib/codemirror-5.49.2/lib/codemirror.js
+++ b/de.bund.bfr.knime.js/js-lib/codemirror-5.49.2/lib/codemirror.js
@@ -8,9 +8,7 @@
 // at http://marijnhaverbeke.nl/blog/#cm-internals .
 
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
-  typeof define === 'function' && define.amd ? define(factory) :
-  (global.CodeMirror = factory());
+    global.CodeMirror = factory();
 }(this, (function () { 'use strict';
 
   // Kludges for bugs and behavior differences that can't be feature

--- a/de.bund.bfr.knime.js/plugin.xml
+++ b/de.bund.bfr.knime.js/plugin.xml
@@ -33,9 +33,10 @@
      </webResourceBundle>
      
      <webResourceBundle name="codemirror" version="5.49.2" webResourceBundleID="codemirror_5.49.2"
-       usesDefine="true" debug="false">    
+        debug="false">    
        <webResource relativePathSource="js-lib/codemirror-5.49.2/" relativePathTarget="codemirror" />
        <importResource relativePath="codemirror/lib/codemirror.css" type="CSS" />
+       <importResource relativePath="codemirror/lib/codemirror.js" type="JAVASCRIPT" />
      </webResourceBundle>
      
      <webResourceBundle name="JointJS" version="3.1.1" webResourceBundleID="JointJS_3.1.1" debug="false">


### PR DESCRIPTION
- This PR is related to a bug in loading the instances of codemirror in Model, visualization scripts and readme in the editor.
- This bug can be observed in the editor only in a workflow deployed to the server and requested via the browser
- Desktop version of the editor was and still working fine.
- I included here a fix for scripts saving bug (https://github.com/RakipInitiative/ModelRepository/issues/287) as it's related somehow to this PR.