### PR TITLE
parameter classification is converted to uppercase.

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/js-src/de/bund/bfr/knime/fsklab/v2.0/editor/editor.js
+++ b/de.bund.bfr.knime.fsklab.nodes/js-src/de/bund/bfr/knime/fsklab/v2.0/editor/editor.js
@@ -36,6 +36,9 @@ fskeditorjs = function () {
     //}
   }
   let doSave = function(_metadatax){
+	 _metadatax.modelMath.parameter.forEach(param => {
+		param.classification = param.classification.toUpperCase()
+		});
     _metadatax.modelMath.parameter.forEach(param => {
       if(param.classification != "OUTPUT"){ 
         _simulation.forEach(simulation => {


### PR DESCRIPTION
This needs to be removed once the implementation correctly uses
camelcase for the parameter classification.
Relates to the ticket https://app.zenhub.com/workspaces/online-model-repository-5e4bc0198f780f014bf8f3f3/issues/rakipinitiative/modelrepository/289