### PR TITLE
the static checkbox variable was a mistake. Fixed.

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
@@ -34,7 +34,15 @@ public abstract class ScriptHandler implements AutoCloseable {
 
   protected ModelPlotter plotter;
   protected JsonHandler jsonHandler;
-
+  private boolean saveToJsonChecked = false;
+  /**
+   * Setter method to decide if parameters should be written to JSON 
+   * @param saveToJsonChecked the value from the Runner "save to 
+   * json file" checkbox.
+   */
+  public final void setSaveToJsonChecked(boolean saveToJsonChecked) {
+    this.saveToJsonChecked = saveToJsonChecked;
+  }
   /**
    * This template method runs a snippet of script code. It does not save the stdOutput or the
    * stdErrOutput. After running this method, "cleanup" has to be called in order to close the
@@ -103,7 +111,7 @@ public abstract class ScriptHandler implements AutoCloseable {
 
     // JsonHandler stores all input parameters before model execution
 
-    if(RunnerNodeModel.SAVETOJSON) {
+    if(saveToJsonChecked) {
       jsonHandler.saveInputParameters(fskObj);
     }
       
@@ -154,7 +162,7 @@ public abstract class ScriptHandler implements AutoCloseable {
     saveWorkspace(fskObj, exec);
 
     // HDFHandler stores all ouput parameters in HDF file
-    if(RunnerNodeModel.SAVETOJSON) {
+    if(saveToJsonChecked) {
       jsonHandler.saveOutputParameters(fskObj, workingDirectory);
     }
       
@@ -415,7 +423,7 @@ public abstract class ScriptHandler implements AutoCloseable {
       }
 
       // Save JSON file
-      if (RunnerNodeModel.SAVETOJSON) {
+      if (saveToJsonChecked) {
         File sourceFile = new File(workingDirectory, JsonHandler.JSON_FILE_NAME);
         File targetFile = new File(newResourcesDirectory, JsonHandler.JSON_FILE_NAME);
         FileUtil.copy(sourceFile, targetFile, exec);

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/runner/RunnerNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/runner/RunnerNodeModel.java
@@ -77,7 +77,7 @@ public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjec
 
   private final RunnerNodeInternalSettings internalSettings = new RunnerNodeInternalSettings();
   /** Config identifier saveToJson */
-  public static boolean SAVETOJSON = false;
+  private boolean saveToJsonChecked = false;
 
   private RunnerNodeSettings nodeSettings = new RunnerNodeSettings();
   private FskPortObject fskObj = null;
@@ -363,7 +363,7 @@ public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjec
     if (fskObj instanceof CombinedFskPortObject) {
       
       // enable saving output parameters to JSON file
-      SAVETOJSON = true;
+      saveToJsonChecked = true;
       
       CombinedFskPortObject comFskObj = (CombinedFskPortObject) fskObj;
 
@@ -430,7 +430,7 @@ public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjec
     } else {
       LOGGER.info("Running simulation: " + nodeSettings.simulation);
 
-      SAVETOJSON = nodeSettings.saveToJson;
+      saveToJsonChecked = nodeSettings.saveToJson;
       
       FskSimulation fskSimulation;
       if (!nodeSettings.simulation.isEmpty()) {
@@ -487,6 +487,8 @@ public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjec
     try (ScriptHandler handler = ScriptHandler
         .createHandler(SwaggerUtil.getLanguageWrittenIn(fskObj.modelMetadata), fskObj.packages)) {
      
+      // give handler info from checkBox that he needs to save parameter data to JSON 
+      handler.setSaveToJsonChecked(saveToJsonChecked);
       handler.runSnippet(fskObj, simulation, exec, LOGGER, internalSettings.imageFile, joinRelationList, suffix);
   
       // process the return value of error capturing and update error and


### PR DESCRIPTION
checkbox "save to json file" was static and executing several runner nodes would overwrite the value causing failures for joined models.