### PR TITLE
Editor bug reference hotfix

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/js-src/de/bund/bfr/knime/fsklab/v2.0/editor/editor.js
+++ b/de.bund.bfr.knime.fsklab.nodes/js-src/de/bund/bfr/knime/fsklab/v2.0/editor/editor.js
@@ -48,7 +48,7 @@ fskeditorjs = function () {
             	if(obj[k] === "-") {
             		delete obj[k];
 	            } else {
-	            	if(obj[k].includes("-undefined")) { // for dates that are un-serializible 
+	            	if((typeof obj[k] === 'string' || obj[k] instanceof String) && obj[k].includes("-undefined")) { // for dates that are un-serializible 
 	            		obj[k] = "";
 	            		delete obj[k];
 		            }


### PR DESCRIPTION
doSave function in editor.js would crash (exception) if a property didn't have the "includes" function