### PR TITLE
added a check for null value for reading date objects

### DIFF
--- a/de.bund.bfr.knime.js/src/js/app/app.editable.mt.SimpleTable.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.editable.mt.SimpleTable.js
@@ -52,7 +52,7 @@ class SimpleTable {
         let input = document.createElement("input");
         input.type = O.type;
         input.className = "form-control";
-        if ($(input).attr('type') === "date" && typeof (value) != "string") {
+        if ($(input).attr('type') === "date" && typeof (value) != "string" && value !== null) {
             let day = ("" + value[2]).length > 1 ? ("" + value[2]) : ("0" + value[2]);
             let month = ("" + value[1]).length > 1 ? ("" + value[1]) : ("0" + value[1]);
             $(input).val(value[0] + "-" + month + "-" + day);


### PR DESCRIPTION
When opening a model with the editor which contains a modification date [ null ] for whatever reason, the view doesn't load. I added a check for null in this case.
The problem occurs when adding a modification date but leaving it untouched (no actual date given). In that case, when writing the model, reading it again and trying to edit it, the error is thrown.