### PR TITLE
Sets identifier in initializeModel

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes.tests/src/de/bund/bfr/knime/fsklab/nodes/NodeUtilsTest.java
+++ b/de.bund.bfr.knime.fsklab.nodes.tests/src/de/bund/bfr/knime/fsklab/nodes/NodeUtilsTest.java
@@ -3,12 +3,15 @@ package de.bund.bfr.knime.fsklab.nodes;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 
 import de.bund.bfr.knime.fsklab.v2_0.editor.FSKEditorJSNodeDialog.ModelType;
 import de.bund.bfr.metadata.swagger.ConsumptionModel;
 import de.bund.bfr.metadata.swagger.DataModel;
+import de.bund.bfr.metadata.swagger.DataModelGeneralInformation;
 import de.bund.bfr.metadata.swagger.DoseResponseModel;
 import de.bund.bfr.metadata.swagger.DoseResponseModelGeneralInformation;
 import de.bund.bfr.metadata.swagger.ExposureModel;
@@ -35,6 +38,8 @@ public class NodeUtilsTest {
 		
 		GenericModelGeneralInformation information = ((GenericModel)model).getGeneralInformation();
 		assertEquals("Generic model", information.getModelCategory().getModelClass());
+		
+		assertTrue(StringUtils.isNotEmpty(information.getIdentifier()));
 	}
 
 	@Test
@@ -44,6 +49,9 @@ public class NodeUtilsTest {
 		assertEquals("dataModel", model.getModelType());
 
 		// TODO: Data model has no ModelCategory
+		DataModelGeneralInformation information = ((DataModel)model).getGeneralInformation();
+		
+		assertTrue(StringUtils.isNotEmpty(information.getIdentifier()));
 	}
 
 	@Test
@@ -54,6 +62,8 @@ public class NodeUtilsTest {
 		
 		PredictiveModelGeneralInformation information = ((ConsumptionModel) model).getGeneralInformation();
 		assertEquals("Consumption model", information.getModelCategory().getModelClass());
+		
+		assertTrue(StringUtils.isNotEmpty(information.getIdentifier()));
 	}
 	
 	@Test
@@ -64,6 +74,8 @@ public class NodeUtilsTest {
 		
 		DoseResponseModelGeneralInformation information = ((DoseResponseModel) model).getGeneralInformation();
 		assertEquals("Dose-response model", information.getModelCategory().getModelClass());
+		
+		assertTrue(StringUtils.isNotEmpty(information.getIdentifier()));
 	}
 
 	@Test
@@ -74,6 +86,8 @@ public class NodeUtilsTest {
 		
 		PredictiveModelGeneralInformation information = ((ExposureModel) model).getGeneralInformation();
 		assertEquals("Exposure model", information.getModelCategory().getModelClass());
+		
+		assertTrue(StringUtils.isNotEmpty(information.getIdentifier()));
 	}
 
 	@Test
@@ -84,6 +98,8 @@ public class NodeUtilsTest {
 		
 		PredictiveModelGeneralInformation information = ((HealthModel) model).getGeneralInformation();
 		assertEquals("Health metrics model", information.getModelCategory().getModelClass());
+		
+		assertTrue(StringUtils.isNotEmpty(information.getIdentifier()));
 	}
 
 	@Test
@@ -94,6 +110,8 @@ public class NodeUtilsTest {
 		
 		OtherModelGeneralInformation information = ((OtherModel) model).getGeneralInformation();
 		assertEquals("Other empirical models", information.getModelCategory().getModelClass());
+		
+		assertTrue(StringUtils.isNotEmpty(information.getIdentifier()));
 	}
 
 	@Test
@@ -104,6 +122,8 @@ public class NodeUtilsTest {
 		
 		PredictiveModelGeneralInformation information = ((PredictiveModel) model).getGeneralInformation();
 		assertEquals("Predictive model", information.getModelCategory().getModelClass());
+		
+		assertTrue(StringUtils.isNotEmpty(information.getIdentifier()));
 	}
 
 	@Test
@@ -114,6 +134,8 @@ public class NodeUtilsTest {
 		
 		PredictiveModelGeneralInformation information = ((ProcessModel) model).getGeneralInformation();
 		assertEquals("Process model", information.getModelCategory().getModelClass());
+		
+		assertTrue(StringUtils.isNotEmpty(information.getIdentifier()));
 	}
 	
 	@Test
@@ -124,6 +146,8 @@ public class NodeUtilsTest {
 
 		PredictiveModelGeneralInformation information = ((QraModel) model).getGeneralInformation();
 		assertEquals("Quantitative risk assessment", information.getModelCategory().getModelClass());
+		
+		assertTrue(StringUtils.isNotEmpty(information.getIdentifier()));
 	}
 	
 	@Test
@@ -134,6 +158,8 @@ public class NodeUtilsTest {
 
 		PredictiveModelGeneralInformation information = ((RiskModel) model).getGeneralInformation();
 		assertEquals("Risk characterization model", information.getModelCategory().getModelClass());
+		
+		assertTrue(StringUtils.isNotEmpty(information.getIdentifier()));
 	}
 
 	@Test
@@ -144,6 +170,8 @@ public class NodeUtilsTest {
 
 		PredictiveModelGeneralInformation information = ((ToxicologicalModel) model).getGeneralInformation();
 		assertEquals("Toxicological reference value", information.getModelCategory().getModelClass());
+		
+		assertTrue(StringUtils.isNotEmpty(information.getIdentifier()));
 	}
 
 	@Test
@@ -154,5 +182,7 @@ public class NodeUtilsTest {
 
 		GenericModelGeneralInformation information = ((GenericModel)model).getGeneralInformation();
 		assertEquals("Generic model", information.getModelCategory().getModelClass());
+		
+		assertTrue(StringUtils.isNotEmpty(information.getIdentifier()));
 	}
 }

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/NodeUtils.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/NodeUtils.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.knime.core.node.InvalidSettingsException;
 import org.knime.core.node.workflow.FlowVariable;
@@ -18,6 +19,7 @@ import de.bund.bfr.metadata.swagger.Assay;
 import de.bund.bfr.metadata.swagger.ConsumptionModel;
 import de.bund.bfr.metadata.swagger.Contact;
 import de.bund.bfr.metadata.swagger.DataModel;
+import de.bund.bfr.metadata.swagger.DataModelGeneralInformation;
 import de.bund.bfr.metadata.swagger.DietaryAssessmentMethod;
 import de.bund.bfr.metadata.swagger.DoseResponseModel;
 import de.bund.bfr.metadata.swagger.DoseResponseModelGeneralInformation;
@@ -161,12 +163,18 @@ public class NodeUtils {
           .modelType("genericModel");
   }
 
-  /** Initialize and return a model for the passed type. */
+  /**
+   * Initialise and return a model for the passed type. The model is initialised
+   * with an UUID and its model class.
+   */
   public static Model initializeModel(ModelType modelType) {
+    
+    String modelId = UUID.randomUUID().toString();
 
     if (modelType == null)
       return new GenericModel()
           .generalInformation(new GenericModelGeneralInformation()
+              .identifier(modelId)
               .modelCategory(new ModelCategory().modelClass("Generic model")))
           .modelType("genericModel");
 
@@ -174,63 +182,77 @@ public class NodeUtils {
       case genericModel:
         return new GenericModel().modelMath(new GenericModelModelMath())
             .generalInformation(new GenericModelGeneralInformation()
+                .identifier(modelId)
                 .modelCategory(new ModelCategory().modelClass("Generic model")))
             .modelType("genericModel");
       case dataModel:
-        return new DataModel().modelType("dataModel");
+        return new DataModel()
+            .generalInformation(new DataModelGeneralInformation().identifier(modelId))
+            .modelType("dataModel");
       case consumptionModel:
         return new ConsumptionModel()
             .generalInformation(new PredictiveModelGeneralInformation()
+                .identifier(modelId)
                 .modelCategory(new ModelCategory().modelClass("Consumption model")))
             .modelType("consumptionModel");
       case doseResponseModel:
         return new DoseResponseModel()
             .generalInformation(new DoseResponseModelGeneralInformation()
+                .identifier(modelId)
                 .modelCategory(new ModelCategory().modelClass("Dose-response model")))
             .modelType("doseResponseModel");
       case exposureModel:
         return new ExposureModel()
             .generalInformation(new PredictiveModelGeneralInformation()
+                .identifier(modelId)
                 .modelCategory(new ModelCategory().modelClass("Exposure model")))
             .modelType("exposureModel");
       case healthModel:
         return new HealthModel()
             .generalInformation(new PredictiveModelGeneralInformation()
+                .identifier(modelId)
                 .modelCategory(new ModelCategory().modelClass("Health metrics model")))
             .modelType("healthModel");
       case otherModel:
         return new OtherModel()
             .generalInformation(new OtherModelGeneralInformation()
+                .identifier(modelId)
                 .modelCategory(new ModelCategory().modelClass("Other empirical models")))
             .modelType("otherModel");
       case predictiveModel:
         return new PredictiveModel()
             .generalInformation(new PredictiveModelGeneralInformation()
+                .identifier(modelId)
                 .modelCategory(new ModelCategory().modelClass("Predictive model")))
             .modelType("predictiveModel");
       case processModel:
         return new ProcessModel()
             .generalInformation(new PredictiveModelGeneralInformation()
+                .identifier(modelId)
                 .modelCategory(new ModelCategory().modelClass("Process model")))
             .modelType("processModel");
       case qraModel:
         return new QraModel()
             .generalInformation(new PredictiveModelGeneralInformation()
+                .identifier(modelId)
                 .modelCategory(new ModelCategory().modelClass("Quantitative risk assessment")))
             .modelType("qraModel");
       case riskModel:
         return new RiskModel()
             .generalInformation(new PredictiveModelGeneralInformation()
+                .identifier(modelId)
                 .modelCategory(new ModelCategory().modelClass("Risk characterization model")))
             .modelType("riskModel");
       case toxicologicalModel:
         return new ToxicologicalModel()
             .generalInformation(new PredictiveModelGeneralInformation()
+                .identifier(modelId)
                 .modelCategory(new ModelCategory().modelClass("Toxicological reference value")))
             .modelType("toxicologicalModel");
       default:
         return new GenericModel()
             .generalInformation(new GenericModelGeneralInformation()
+                .identifier(modelId)
                 .modelCategory(new ModelCategory().modelClass("Generic model")))
             .modelType("genericModel");
     }


### PR DESCRIPTION
NodeUtils.initializeModel is updated to include general information and a model identifier for every model class. This will simplify initialising models in the nodes as they use NodeUtils and have to check later the identifier.

These are small changes but they will simplify a lot the changes needed in the editor.