### PR TITLE
Editor bug picking a model from configuration dropdown menu fails node

### DIFF
--- a/de.bund.bfr.knime.fsklab.metadata.model/src/metadata/ConversionUtils.java
+++ b/de.bund.bfr.knime.fsklab.metadata.model/src/metadata/ConversionUtils.java
@@ -183,12 +183,14 @@ public class ConversionUtils {
 
 	private JsonNode convert(JsonNode originalMetadata, Map<String, Object> originalClass,
 			Map<String, Object> targetClass) {
-
+  	    if(originalMetadata == null) {
+          return null;
+        }
 		Map<String, Object> originalProperties = getProperties(originalClass);
 		Map<String, Object> targetProperties = getProperties(targetClass);
 
 		ObjectNode node = MAPPER.createObjectNode();
-
+		
 		Iterator<Entry<String, JsonNode>> fields = originalMetadata.fields();
 		while (fields.hasNext()) {
 			Entry<String, JsonNode> field = fields.next();

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/NodeUtils.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/NodeUtils.java
@@ -21,6 +21,7 @@ import de.bund.bfr.metadata.swagger.DataModel;
 import de.bund.bfr.metadata.swagger.DietaryAssessmentMethod;
 import de.bund.bfr.metadata.swagger.DoseResponseModel;
 import de.bund.bfr.metadata.swagger.DoseResponseModelGeneralInformation;
+import de.bund.bfr.metadata.swagger.DoseResponseModelModelMath;
 import de.bund.bfr.metadata.swagger.Exposure;
 import de.bund.bfr.metadata.swagger.ExposureModel;
 import de.bund.bfr.metadata.swagger.GenericModel;
@@ -36,11 +37,13 @@ import de.bund.bfr.metadata.swagger.ModelCategory;
 import de.bund.bfr.metadata.swagger.ModelEquation;
 import de.bund.bfr.metadata.swagger.OtherModel;
 import de.bund.bfr.metadata.swagger.OtherModelGeneralInformation;
+import de.bund.bfr.metadata.swagger.OtherModelModelMath;
 import de.bund.bfr.metadata.swagger.Parameter;
 import de.bund.bfr.metadata.swagger.Parameter.ClassificationEnum;
 import de.bund.bfr.metadata.swagger.PopulationGroup;
 import de.bund.bfr.metadata.swagger.PredictiveModel;
 import de.bund.bfr.metadata.swagger.PredictiveModelGeneralInformation;
+import de.bund.bfr.metadata.swagger.PredictiveModelModelMath;
 import de.bund.bfr.metadata.swagger.ProcessModel;
 import de.bund.bfr.metadata.swagger.Product;
 import de.bund.bfr.metadata.swagger.QraModel;
@@ -179,57 +182,57 @@ public class NodeUtils {
       case dataModel:
         return new DataModel().modelType("dataModel");
       case consumptionModel:
-        return new ConsumptionModel()
+        return new ConsumptionModel().modelMath(new PredictiveModelModelMath())
             .generalInformation(new PredictiveModelGeneralInformation()
                 .modelCategory(new ModelCategory().modelClass("Consumption model")))
             .modelType("consumptionModel");
       case doseResponseModel:
-        return new DoseResponseModel()
+        return new DoseResponseModel().modelMath(new DoseResponseModelModelMath())
             .generalInformation(new DoseResponseModelGeneralInformation()
                 .modelCategory(new ModelCategory().modelClass("Dose-response model")))
             .modelType("doseResponseModel");
       case exposureModel:
-        return new ExposureModel()
+        return new ExposureModel().modelMath(new GenericModelModelMath())
             .generalInformation(new PredictiveModelGeneralInformation()
                 .modelCategory(new ModelCategory().modelClass("Exposure model")))
             .modelType("exposureModel");
       case healthModel:
-        return new HealthModel()
+        return new HealthModel().modelMath(new GenericModelModelMath())
             .generalInformation(new PredictiveModelGeneralInformation()
                 .modelCategory(new ModelCategory().modelClass("Health metrics model")))
             .modelType("healthModel");
       case otherModel:
-        return new OtherModel()
+        return new OtherModel().modelMath(new OtherModelModelMath())
             .generalInformation(new OtherModelGeneralInformation()
                 .modelCategory(new ModelCategory().modelClass("Other empirical models")))
             .modelType("otherModel");
       case predictiveModel:
-        return new PredictiveModel()
+        return new PredictiveModel().modelMath(new PredictiveModelModelMath())
             .generalInformation(new PredictiveModelGeneralInformation()
                 .modelCategory(new ModelCategory().modelClass("Predictive model")))
             .modelType("predictiveModel");
       case processModel:
-        return new ProcessModel()
+        return new ProcessModel().modelMath(new PredictiveModelModelMath())
             .generalInformation(new PredictiveModelGeneralInformation()
                 .modelCategory(new ModelCategory().modelClass("Process model")))
             .modelType("processModel");
       case qraModel:
-        return new QraModel()
+        return new QraModel().modelMath(new GenericModelModelMath())
             .generalInformation(new PredictiveModelGeneralInformation()
                 .modelCategory(new ModelCategory().modelClass("Quantitative risk assessment")))
             .modelType("qraModel");
       case riskModel:
-        return new RiskModel()
+        return new RiskModel().modelMath(new GenericModelModelMath())
             .generalInformation(new PredictiveModelGeneralInformation()
                 .modelCategory(new ModelCategory().modelClass("Risk characterization model")))
             .modelType("riskModel");
       case toxicologicalModel:
-        return new ToxicologicalModel()
+        return new ToxicologicalModel().modelMath(new GenericModelModelMath())
             .generalInformation(new PredictiveModelGeneralInformation()
                 .modelCategory(new ModelCategory().modelClass("Toxicological reference value")))
             .modelType("toxicologicalModel");
       default:
-        return new GenericModel()
+        return new GenericModel().modelMath(new GenericModelModelMath())
             .generalInformation(new GenericModelGeneralInformation()
                 .modelCategory(new ModelCategory().modelClass("Generic model")))
             .modelType("genericModel");

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
@@ -314,10 +314,12 @@ final class FSKEditorJSNodeModel
         metadata = MAPPER.readValue(viewValue.getModelMetaData(), modelClass);
         if(!StringUtils.isEmpty(viewRep.getModelMetadata())) {
           if( m_config.getModelType().equals(modelType)) {
-            originalMetadata =  new ConversionUtils().convertModel(MAPPER.readTree(viewRep.getModelMetadata()),
+            metadata =  new ConversionUtils().convertModel(MAPPER.readTree(viewRep.getModelMetadata()),
                   ConversionUtils.ModelClass.valueOf(m_config.getModelType()));
+            viewRep.setModelMetadata(MAPPER.writeValueAsString(metadata));
+            viewValue.setModelMetaData(MAPPER.writeValueAsString(metadata));
           }else {
-            originalMetadata = MAPPER.readValue(viewRep.getModelMetadata(), modelClass);
+            metadata = MAPPER.readValue(viewRep.getModelMetadata(), modelClass);
           }
          
         }
@@ -325,9 +327,10 @@ final class FSKEditorJSNodeModel
           if(!StringUtils.isEmpty(portObjectModelType) && !portObjectModelType.equals(modelType)) {
             String json = MAPPER.writeValueAsString(((FskPortObject)inObjects[0]).modelMetadata);
             JsonNode portMetadata = MAPPER.readTree(json);
-            Model convertedModel = new ConversionUtils().convertModel(portMetadata,
+            metadata = new ConversionUtils().convertModel(portMetadata,
                 ConversionUtils.ModelClass.valueOf(m_config.getModelType()));
-            viewRep.setModelMetadata(MAPPER.writeValueAsString(convertedModel));
+            viewRep.setModelMetadata(MAPPER.writeValueAsString(metadata));
+            viewValue.setModelMetaData(MAPPER.writeValueAsString(metadata));
           }else {
             viewRep.setModelMetadata(jsonMetadata);
           }

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
@@ -315,7 +315,7 @@ final class FSKEditorJSNodeModel
         if(!StringUtils.isEmpty(viewRep.getModelMetadata())) {
           JsonNode repMetadataNode = MAPPER.readTree(viewRep.getModelMetadata());
           String repModelType = repMetadataNode.get("modelType").asText("genericModel");
-          if(!m_config.getModelType().equals(repModelType)) {
+          if(m_config.getModelType() != null &&  !m_config.getModelType().equals(repModelType)) {
             metadata =  new ConversionUtils().convertModel(MAPPER.readTree(viewRep.getModelMetadata()),
                   ConversionUtils.ModelClass.valueOf(m_config.getModelType()));
             viewRep.setModelMetadata(MAPPER.writeValueAsString(metadata));

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
@@ -322,7 +322,7 @@ final class FSKEditorJSNodeModel
             viewValue.setModelMetaData(MAPPER.writeValueAsString(metadata));
             
 
-          }else if(!StringUtils.isEmpty(portObjectModelType) && !portObjectModelType.equals(modelType)) {
+          }else if(!StringUtils.isEmpty(portObjectModelType) && !portObjectModelType.equalsIgnoreCase(modelType)) {
             String json = MAPPER.writeValueAsString(((FskPortObject)inObjects[0]).modelMetadata);
             JsonNode portMetadata = MAPPER.readTree(json);
             metadata = new ConversionUtils().convertModel(portMetadata,

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
@@ -344,8 +344,7 @@ final class FSKEditorJSNodeModel
             metadata = new ConversionUtils().convertModel(portMetadata,
                 ConversionUtils.ModelClass.valueOf(m_config.getModelType()));
             
-            if(inObjects[0] != null)
-              copyConnectedNodeToView("", viewValue);
+            copyConnectedNodeToView("", viewValue);
             viewRep.setModelMetadata(MAPPER.writeValueAsString(metadata));
             viewValue.setModelMetaData(MAPPER.writeValueAsString(metadata));
           }else {


### PR DESCRIPTION
https://github.com/RakipInitiative/ModelRepository/issues/304
- the NPM is caused by missing ModelMath in all model except generic model.
- this PR applies conversion utils to convert models from one model provided via port, this is usefull when connecting one node with some model type with another node and selecting another model type 
- also this conversion is applied on nodes with saved model metadata via `save as default or temporarily` which setup with a new model type.