### PR TITLE
validate integer values

### DIFF
--- a/de.bund.bfr.knime.js/src/js/app/app.simulation.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.simulation.js
@@ -952,7 +952,13 @@ class APPSimulation {
 				// check range for integers and doubles
 				if ( field.param.dataType.toLowerCase() === 'integer' 
 					|| field.param.dataType.toLowerCase() === 'double' ) {
-
+                    
+                    if ( field.param.dataType.toLowerCase === 'integer' && fieldValue.indexOf('.') > 0 ){
+                        return {
+                                input   : field.input,
+                                msg     : 'Invalid integer value'
+                            };
+                    }
 					if ( field.param.minValue && parseFloat( field.param.minValue ) > fieldValue ) {
 						return {
 							input  	: field.input,


### PR DESCRIPTION
https://github.com/SiLeBAT/FSK-Lab/issues/489
@schuelet:
for interger and double only numeric values are allowed (already provided via the component) but I added Integer validation.
for other data types (in my point of view ) this will rais some limitation to the user freedom in providing the values. String values could be a literal string starting and end with `"` or could be an assignment to another string variable. there a lot of ways to define a matrix vector or boolean.