### PR TITLE
relaxed constraint of file parameters being accessible after execution

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/FskErrorMessages.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/FskErrorMessages.java
@@ -29,6 +29,32 @@ public class FskErrorMessages {
     }
     return objectNullMessage(variableName);
   }
+  
+  /**
+   * Warning message when a variable that should be accessible as a file but is either 
+   * not available in the workspace or just a script command reading 
+   * a file, e.g. "read.csv("file.csv") 
+   * 
+   *  
+   * @param variableName name of the file variable
+   * @param modelId ID of model currently executed
+   * @return error/warning message
+   */
+  public static String variableAccessWarning(String variableName, String modelId) {
+    if (isNotNull("Variable", variableName) && isNotNull("Model ID", modelId)) {
+      String msg ="WARNING: FILE parameter '" + variableName + "' of model '" + modelId
+          + "' is not accessible as a filename. Make sure the variable is global and check "
+          + "its value. File parameters should only have their file name + extension as a value";
+      LOGGER.warn(msg);
+      return msg;
+    } else {
+      if (isNotNull("Variable", variableName)) {
+        return objectNullMessage(modelId);
+      }
+    }
+    return objectNullMessage(variableName);
+  }
+  
 
   /**
    * Warning message when a generated resource (OUTPUT FILE) was not found. Usage:

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
@@ -417,8 +417,14 @@ public abstract class ScriptHandler implements AutoCloseable {
             }
           }
         } catch (REXPMismatchException | IOException | RException | InterruptedException e) {
-          throw new VariableNotGlobalException(command,
+
+          FskErrorMessages.variableAccessWarning(command, 
               SwaggerUtil.getModelId(fskPortObject.modelMetadata));
+
+          if (saveToJsonChecked) {
+            throw new VariableNotGlobalException(command,
+                SwaggerUtil.getModelId(fskPortObject.modelMetadata));  
+          } 
         }
       }
 


### PR DESCRIPTION
File parameters that are not correctly declared or not accessible in the
workspace will no longer fail the execution of the node IF the user
doesn't use the model for joining or insists of writing the
paramater.json file.