### PR TITLE
fixed a bug where min/maxValue of parameters would brick slider

### DIFF
--- a/de.bund.bfr.knime.js/src/js/app/app.simulation.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.simulation.js
@@ -330,7 +330,7 @@ class APPSimulation {
 						.appendTo( $inputGroup );
 
 					// rangeslider single, if min/max
-					if ( param.minValue && param.maxValue ) {
+					if ( param.minValue && param.maxValue  && param.minValue != "-" && param.maxValue != "-") {
 
 						let step = 1;
 						// calc decimals for slider steps depending on min-max values


### PR DESCRIPTION
In Simulation Configurator: when a model has a parameter which has a
minValue/maxValue of "-" then the view would still draw a slider from
NaN to NaN, making it impossible to edit this parameter. The NaN value
was also taken as new value when saving the Configurator.