### PR TITLE
added a flow-variable to Runner outport saying which simulation it used

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/runner/RunnerNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/runner/RunnerNodeModel.java
@@ -183,9 +183,9 @@ public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjec
     }
     
     // add flow-variable stating which simulation (name) was executed
-        String simulationName = fskObj.simulations != null 
-            ? fskObj.simulations.get(fskObj.selectedSimulationIndex).getName()
-                : "defaultSimulation";
+    String simulationName = fskObj.simulations != null
+        ? fskObj.simulations.get(fskObj.selectedSimulationIndex).getName()
+            : "defaultSimulation";
     this.pushFlowVariableString("selectedSimulation", simulationName);
     
     if(isVisScriptEmpty(fskObj)) {

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/runner/RunnerNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/runner/RunnerNodeModel.java
@@ -182,6 +182,12 @@ public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjec
           fskObj.getGeneratedResourcesDirectory().get().getAbsolutePath());
     }
     
+    // add flow-variable stating which simulation (name) was executed
+        String simulationName = fskObj.simulations != null 
+            ? fskObj.simulations.get(fskObj.selectedSimulationIndex).getName()
+                : "defaultSimulation";
+    this.pushFlowVariableString("selectedSimulation", simulationName);
+    
     if(isVisScriptEmpty(fskObj)) {
       LOGGER.warn("There is no visualization script");
       String noImage = "<?xml version=\"1.0\"?>\n"


### PR DESCRIPTION
There seems to be no other way to determine which simulation the Runner
used on execution, so I added a flow-variable with that information.