### PR TITLE
fix CombineArchive concurrent access issue

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/environment/ArchivedEnvironmentManager.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/environment/ArchivedEnvironmentManager.java
@@ -14,7 +14,8 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import de.unirostock.sems.cbarchive.ArchiveEntry;
 import de.unirostock.sems.cbarchive.CombineArchive;
 import de.unirostock.sems.cbarchive.CombineArchiveException;
-
+import static de.bund.bfr.knime.fsklab.v2_0.reader.ReaderNodeUtil.lock;
+import static de.bund.bfr.knime.fsklab.v2_0.reader.ReaderNodeUtil.release;
 /**
  * ArchivedEnvironmentManager handles working directories contained within FSKX archives. If the
  * passed archive path is null, empty string, does not exist or has no resource entries,
@@ -69,7 +70,8 @@ public class ArchivedEnvironmentManager implements EnvironmentManager {
 
     if (entries == null || entries.length == 0)
       return Optional.empty();
-
+    lock(archiveFile.toFile());
+    
     try (CombineArchive archive = new CombineArchive(archiveFile.toFile())) {
 
       Path environment = Files.createTempDirectory("workingDirectory");
@@ -84,6 +86,9 @@ public class ArchivedEnvironmentManager implements EnvironmentManager {
 
     } catch (IOException | JDOMException | ParseException | CombineArchiveException e) {
       return Optional.empty();
+    }
+    finally {
+      release(archiveFile.toFile());
     }
   }
 

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/reader/ReaderNodeUtil.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/reader/ReaderNodeUtil.java
@@ -628,16 +628,10 @@ public class ReaderNodeUtil {
       return fskObj;
     }
   }
-  /**
-   * 
-   * @param in a file to be read and converted into FSK Object
-   * @return FskPortObject
-   * @throws Exception
-   */
-  public static FskPortObject readArchive(File in) throws Exception {
-    FskPortObject fskObj = null;
+  public static void lock(File in) {
     try {
       lock.lock();
+      
       if(!FSKFilesRegistry.contains(in.getPath())) {
         FSKFilesRegistry.add(in.getPath());
       }else {
@@ -646,10 +640,26 @@ public class ReaderNodeUtil {
         }
         FSKFilesRegistry.add(in.getPath());
       }
+    } catch (InterruptedException e) {
+      e.printStackTrace();
     }
     finally {
       lock.unlock();
     }
+  }
+  public static void release(File in) {
+    FSKFilesRegistry.remove(in.getPath());
+  }
+  
+  /**
+   * 
+   * @param in a file to be read and converted into FSK Object
+   * @return FskPortObject
+   * @throws Exception
+   */
+  public static FskPortObject readArchive(File in) throws Exception {
+    FskPortObject fskObj = null;
+    lock(in);
     try (final CombineArchive archive = new CombineArchive(in)) {
 
       // 1. Get SBML URI
@@ -686,7 +696,7 @@ public class ReaderNodeUtil {
       fskObj = readFskPortObject(archive, modelFolders, 0);
     }
     finally {
-      FSKFilesRegistry.remove(in.getPath());
+      release(in);
     }
     
 


### PR DESCRIPTION
@schuelet:
I did before this PR a stress test trying to access the same file from 200 reader nodes at the same time and that passed successfuly.
also run two copies of the huge reader workflow from two different knime instances, trying to access the same poor file hundreds of times concurrently from two different JVM and that passed successfuly.

I do see the CombineArchive issue only in the Reader if there other places please issue it to me.