### PR TITLE
R libraries management

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
@@ -5,12 +5,14 @@ import de.bund.bfr.knime.fsklab.nodes.plot.Ggplot2Plotter;
 import de.bund.bfr.knime.fsklab.r.client.IRController.RException;
 import de.bund.bfr.knime.fsklab.r.client.LibRegistry;
 import de.bund.bfr.knime.fsklab.r.client.RController;
+import de.bund.bfr.knime.fsklab.r.client.RprofileManager;
 import de.bund.bfr.knime.fsklab.r.client.ScriptExecutor;
 import de.bund.bfr.knime.fsklab.v2_0.FskPortObject;
 import de.bund.bfr.knime.fsklab.v2_0.FskSimulation;
 import de.bund.bfr.knime.fsklab.v2_0.runner.RunnerNodeInternalSettings;
 import de.bund.bfr.knime.fsklab.v2_0.runner.RunnerNodeSettings;
 import de.bund.bfr.metadata.swagger.Parameter;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,11 +33,12 @@ public class RScriptHandler extends ScriptHandler {
   ScriptExecutor executor;
   RController controller;
 
-  public RScriptHandler() throws RException {
+  public RScriptHandler() throws RException, IOException {
     this(new ArrayList<String>(0));
   }
 
-  public RScriptHandler(List<String> packages) throws RException {
+  public RScriptHandler(List<String> packages) throws RException, IOException {
+    RprofileManager.subscribe();
     this.controller = new RController();
     this.executor = new ScriptExecutor(controller);
 
@@ -167,6 +170,7 @@ public class RScriptHandler extends ScriptHandler {
   @Override
   public void cleanup(ExecutionContext exec) throws Exception {
     executor.cleanup(exec);
+    RprofileManager.unSubscribe();
   }
 
   @Override

--- a/de.bund.bfr.knime.fsklab.preferences/src/de/bund/bfr/knime/fsklab/preferences/PreferenceInitializer.java
+++ b/de.bund.bfr.knime.fsklab.preferences/src/de/bund/bfr/knime/fsklab/preferences/PreferenceInitializer.java
@@ -29,10 +29,10 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 	/** Path to R v.3 */
 	static final String R3_PATH_CFG = "r3.path";
 	static final String PYTHON2_PATH_CFG = "python2Path";
-	static final String CV_URL_CFG = "controlledvocabulary.path";
 	private static RPreferenceProvider cachedRProvider = null;
-
-	@Override
+	public static boolean refresh;
+	
+    @Override
 	public void initializeDefaultPreferences() {
 
 		String rHome = "";
@@ -46,7 +46,6 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		IPreferenceStore store = Plugin.getDefault().getPreferenceStore();
 		store.setDefault(R3_PATH_CFG, rHome);
 		store.setDefault(PYTHON2_PATH_CFG, "");
-		store.setDefault(CV_URL_CFG, "https://knime.bfr.berlin/vocabularies-app/");
 	}
 
 	/** @return provider to the path to the R3 executable. */
@@ -59,8 +58,8 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		return cachedRProvider;
 	}
 
-	public static final String getControlledVocabularyURL() {
-		return Plugin.getDefault().getPreferenceStore().getString(CV_URL_CFG);
+	public static final String getRPath() {
+		return Plugin.getDefault().getPreferenceStore().getString(R3_PATH_CFG);
 	}
 	
 	/**

--- a/de.bund.bfr.knime.fsklab.preferences/src/de/bund/bfr/knime/fsklab/preferences/PreferencePage.java
+++ b/de.bund.bfr.knime.fsklab.preferences/src/de/bund/bfr/knime/fsklab/preferences/PreferencePage.java
@@ -53,7 +53,6 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 		Composite parent = getFieldEditorParent();
 		addField(new RHomeDirectoryFieldEditor(PreferenceInitializer.R3_PATH_CFG, "Path to R 3", parent));
 		addField(new DirectoryFieldEditor(PreferenceInitializer.PYTHON2_PATH_CFG, "Path to Python 2", parent));
-		addField(new StringFieldEditor(PreferenceInitializer.CV_URL_CFG, "Controlled vocabulary URL", parent));
 	}
 
 	@Override
@@ -134,6 +133,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 				}
 
 				setMessage(null, NONE);
+	            PreferenceInitializer.refresh = true;
 				return true;
 			} catch (InvalidRHomeException e) {
 				setMessage(e.getMessage(), ERROR);

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
@@ -40,7 +40,7 @@ import org.rosuda.REngine.REXPMismatchException;
 import org.rosuda.REngine.RList;
 
 import com.sun.jna.Platform;
-
+import de.bund.bfr.knime.fsklab.preferences.PreferenceInitializer;
 import de.bund.bfr.knime.fsklab.r.client.IRController.RException;
 
 /**
@@ -53,10 +53,10 @@ public class LibRegistry {
   private static LibRegistry instance;
 
   /** Installation path. */
-  private final Path installPath;
+  private Path installPath;
 
   /** miniCRAN repository path. */
-  private final Path repoPath;
+  private Path repoPath;
 
   /** Utility set to keep count of installed libraries. */
   private final Set<String> installedLibs;
@@ -83,13 +83,23 @@ public class LibRegistry {
     // Prepare rWrapper
     rWrapper = new RWrapper();
     rWrapper.library("miniCRAN");
+    if(!PreferenceInitializer.getRPath().contains(RprofileManager.BFR_R_PLUGIN_NAME)) {
+      try {
+        String[] rPath= controller.eval(".libPaths()", true).asStrings();
+        //get default library path.
+        installPath = Paths.get(rPath[0]);
+        repoPath = installPath.getParent().resolve("cran");
+      } catch (REXPMismatchException | RException e1) {
+        e1.printStackTrace();
+      }
+    }else {
+      Path userFolder = Paths.get(System.getProperty("user.home"));
+      Path fskFolder = userFolder.resolve(".fsk");
 
-    Path userFolder = Paths.get(System.getProperty("user.home"));
-    Path fskFolder = userFolder.resolve(".fsk");
-
-    // CRAN and library folders
-    installPath = fskFolder.resolve("library");
-    repoPath = fskFolder.resolve("cran");
+      // CRAN and library folders
+      installPath = fskFolder.resolve("library");
+      repoPath = fskFolder.resolve("cran");
+    }
 
     // Validate .fsk folder
     if (Files.exists(installPath) && Files.exists(repoPath)) {
@@ -113,7 +123,8 @@ public class LibRegistry {
 
       // Create directories
       Files.createDirectory(repoPath);
-      Files.createDirectory(installPath);
+      if(!Files.exists(installPath))
+        Files.createDirectory(installPath);
 
       // Create CRAN structure in repoPath
       rWrapper.makeRepo(repoPath);
@@ -123,8 +134,9 @@ public class LibRegistry {
   }
 
   public synchronized static LibRegistry instance() throws IOException, RException {
-    if (instance == null) {
+    if (instance == null || PreferenceInitializer.refresh) {
       instance = new LibRegistry();
+      PreferenceInitializer.refresh = false;
     }
     return instance;
   }

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/RprofileManager.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/RprofileManager.java
@@ -1,0 +1,40 @@
+package de.bund.bfr.knime.fsklab.r.client;
+
+import java.io.IOException;
+import java.util.concurrent.locks.ReentrantLock;
+import de.bund.bfr.knime.fsklab.preferences.PreferenceInitializer;
+import de.bund.bfr.knime.fsklab.r.server.RConnectionFactory;
+
+public class RprofileManager {
+
+  private static int rHandlerCount;
+  private static ReentrantLock lock = new ReentrantLock();
+  public final static String BFR_R_PLUGIN_NAME= "de.bund.bfr.binary.r.win32.x86_64_3.4.4";
+  
+  public static void subscribe() throws IOException {
+    try {
+      lock.lock();
+      if (rHandlerCount++ == 0 && PreferenceInitializer.getRPath().contains(BFR_R_PLUGIN_NAME)) {
+        RConnectionFactory.createFskLibrary();
+        RConnectionFactory.backupProfile();
+        RConnectionFactory.configureProfile();
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  public synchronized static void unSubscribe() throws IOException {
+    try {
+      lock.lock();
+      if (--rHandlerCount == 0 && PreferenceInitializer.getRPath().contains(BFR_R_PLUGIN_NAME)) {
+        RConnectionFactory.restoreProfile();
+      }
+    } finally {
+      lock.unlock();
+    }
+
+  }
+
+  
+}


### PR DESCRIPTION
@schuelet: please allow me take part of your email to list what I implemented in this PR:
1. FSK-Lab uses R 3.4.4 bundle: 
    we use only the .fsk folder , and completely ignore any user folders when scanning for installed packages
2. FSK-Lab uses user defined R:
    we don't use the .fsk folder and just use the default library folder, the user has installed. Auto-install of packages goes then   only to the default library folder( the first value returned by calling .libpath() function)
3- if the user decided to change the R setting to use his own R binary rather than BfR R bundle then the LibRegistry instance will be forced to be refreshed.
4. in case the user is using R 3.4.4 bundle and triggers a run then the .RProfile will be configured temporarily during the run to reference the .fsk folder and the original configuration will be restored after finishing the current runner if there is no other runner is still working.

Thanks.