### PR TITLE
workaround for old models

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
@@ -407,7 +407,7 @@ final class FSKEditorJSNodeModel
           }
         }
         else {
-          if(!StringUtils.isEmpty(portObjectModelType) && !portObjectModelType.equals(modelType)) {
+          if(!StringUtils.isEmpty(portObjectModelType) && !portObjectModelType.equalsIgnoreCase(modelType)) {
             String json = MAPPER.writeValueAsString(((FskPortObject)inObjects[0]).modelMetadata);
             JsonNode portMetadata = MAPPER.readTree(json);
             metadata = new ConversionUtils().convertModel(portMetadata,


### PR DESCRIPTION
https://github.com/RakipInitiative/ModelRepository/issues/334
the model have a model metadata type `GenericModel`  and the expected value is `genericModel` 
I don't know how this model is generated but it seems to be an old model.
I added a workaround like in ConversionUtils:ModelClass enum Line 66

