### PR TITLE
executiontime & uploadDate are downloaded in bulk

### DIFF
--- a/de.bund.bfr.knime.js/src/js/app/app.table.mt.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.table.mt.js
@@ -173,8 +173,10 @@ class APPTableMT extends APPTable {
         let O = this;
         _log( 'TABLE MAIN / _createDataMetadata' );
 
-        O._uploadDates = await _fetchData._array( window._endpoints.uploadDate, O._metadata.length ); //O._app._getUploadDates( window._endpoints.uploadDate, O._metadata.length );
-        O._executionTimes = await _fetchData._array( window._endpoints.executionTime, O._metadata.length ); //O._app._getExecutionTimes( window._endpoints.executionTime, O._metadata.length );
+        //O._uploadDates = await _fetchData._array( window._endpoints.uploadDate, O._metadata.length ); //O._app._getUploadDates( window._endpoints.uploadDate, O._metadata.length );
+        //O._executionTimes = await _fetchData._array( window._endpoints.executionTime, O._metadata.length ); //O._app._getExecutionTimes( window._endpoints.executionTime, O._metadata.length );
+        O._uploadDates = await _fetchData._json( window._endpoints.uploadDate); //O._app._getUploadDates( window._endpoints.uploadDate, O._metadata.length );
+        O._executionTimes = await _fetchData._json( window._endpoints.executionTime); //O._app._getExecutionTimes( window._endpoints.executionTime, O._metadata.length );
 
         _log( O._tableData );
     }
@@ -187,6 +189,7 @@ class APPTableMT extends APPTable {
 		for ( let i = 0; i < O._metadata.length; i++ ) {
 
 			let modelMetadata = O._metadata[i]; // full metadata of model
+			var identifier = modelMetadata['generalInformation']['identifier']
 			let rowData = {
 				modelMetadata 	: modelMetadata, // storess full model metadata for callbacks/hooks
 				cells  			: [], // will contain raw cell value
@@ -224,10 +227,10 @@ class APPTableMT extends APPTable {
 					data = modelMetadata['modelType'];
 				}
 				else if ( col.field == 'executionTime' ) {
-					data = O._executionTimes[i];
+					data = O._executionTimes[identifier]? O._executionTimes[identifier] :"";
 				}
 				else if ( col.field == 'uploadDate' ) {
-					data = O._uploadDates[i];
+					data = O._uploadDates[identifier]? O._uploadDates[identifier] :"";
 				}
 
 				rowData.cells.push( data );


### PR DESCRIPTION
@ahmadswaid I changed the frontend to fetch the executionTime/uploadDate in one step each. The endpoints were deployed last weekend. 
The loading time went down from 50s to 25s, so a noticable improvement. 25 seconds for a website to load is still too much, but it is a start.