### PR TITLE
Force terminate unused controllers

### DIFF
--- a/de.bund.bfr.knime.fsklab.deprecatednodes/src-1_7_2/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.deprecatednodes/src-1_7_2/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
@@ -37,6 +37,8 @@ public class RScriptHandler extends ScriptHandler {
 
   public RScriptHandler(List<String> packages) throws RException, IOException {
     RprofileManager.subscribe();
+    // initialize LibRegistry before Controller to avoid errors on switching R in preferences
+    LibRegistry.instance(); 
     this.controller = new RController();
     this.executor = new ScriptExecutor(controller);
     

--- a/de.bund.bfr.knime.fsklab.deprecatednodes/src-1_9_0/de/bund/bfr/knime/fsklab/nodes/v1_9/RScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.deprecatednodes/src-1_9_0/de/bund/bfr/knime/fsklab/nodes/v1_9/RScriptHandler.java
@@ -38,6 +38,8 @@ public class RScriptHandler extends ScriptHandler {
 
   public RScriptHandler(List<String> packages) throws RException, IOException {
     RprofileManager.subscribe();
+    // initialize LibRegistry before Controller to avoid errors on switching R in preferences
+    LibRegistry.instance(); 
     this.controller = new RController();
     this.executor = new ScriptExecutor(controller);
     

--- a/de.bund.bfr.knime.fsklab.deprecatednodes/src-1_9_0/de/bund/bfr/knime/fsklab/v1_9/writer/WriterNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.deprecatednodes/src-1_9_0/de/bund/bfr/knime/fsklab/v1_9/writer/WriterNodeModel.java
@@ -119,7 +119,7 @@ class WriterNodeModel extends NoInternalsModel {
   public static final String METADATA_NS = "fsk";
   public static final String METADATA_COMMAND = "command";
 
-  static ScriptHandler scriptHandler;
+  
 
   static final String CFG_FILE = "file";
   private final SettingsModelString filePath = new SettingsModelString(CFG_FILE, null);
@@ -161,7 +161,7 @@ class WriterNodeModel extends NoInternalsModel {
    * add resource files to archive
    */
   private static void addResourcesToArchive(List<Path> resources, CombineArchive archive,
-      String filePrefix, Map<String, URI> uris) throws Exception {
+      String filePrefix, Map<String, URI> uris, ScriptHandler scriptHandler) throws Exception {
     for (final Path resourcePath : resources) {
 
       final String filenameString = filePrefix + resourcePath.getFileName().toString();
@@ -192,7 +192,7 @@ class WriterNodeModel extends NoInternalsModel {
   }
   
   public static void writeFSKObject(FskPortObject fskObj, CombineArchive archive, String filePrefix,
-      Map<String, URI> URIS) throws Exception {
+      Map<String, URI> URIS, ScriptHandler scriptHandler) throws Exception {
 
     addVersion(archive);
    
@@ -208,7 +208,7 @@ class WriterNodeModel extends NoInternalsModel {
         // Adds resources
         try (Stream<Path> stream = Files.list(workingDirectory.get())) {
           List<Path> resources = stream.collect(Collectors.toList());
-          addResourcesToArchive(resources, archive, filePrefix, URIS);  
+          addResourcesToArchive(resources, archive, filePrefix, URIS, scriptHandler);  
         } catch (Exception e) {
           LOGGER.warn(e.toString());
         }
@@ -219,7 +219,7 @@ class WriterNodeModel extends NoInternalsModel {
     if (fskObj.getGeneratedResourcesDirectory().isPresent()) {
       try (Stream<Path> stream = Files.list(fskObj.getGeneratedResourcesDirectory().get().toPath())) {
         List<Path> resources = stream.collect(Collectors.toList());
-        addResourcesToArchive(resources, archive, filePrefix, URIS);
+        addResourcesToArchive(resources, archive, filePrefix, URIS, scriptHandler);
       } catch (Exception e) {
         LOGGER.warn(e.toString());
       }
@@ -227,12 +227,12 @@ class WriterNodeModel extends NoInternalsModel {
 
     // Adds model script
     final ArchiveEntry modelEntry =
-        addRScript(archive, fskObj.getModel(), filePrefix + "model." + scriptHandler.getFileExtension());
+        addRScript(archive, fskObj.getModel(), filePrefix + "model." + scriptHandler.getFileExtension(), scriptHandler);
     modelEntry.addDescription(new FskMetaDataObject(ResourceType.modelScript).metaDataObject);
 
     // Adds visualization script
     final ArchiveEntry vizEntry = addRScript(archive, fskObj.getViz(),
-        filePrefix + "visualization." + scriptHandler.getFileExtension());
+        filePrefix + "visualization." + scriptHandler.getFileExtension(), scriptHandler);
     vizEntry.addDescription(new FskMetaDataObject(ResourceType.visualizationScript).metaDataObject);
 
     // Adds R workspace file
@@ -241,7 +241,7 @@ class WriterNodeModel extends NoInternalsModel {
     }
     // Add simulations
     {
-      SEDMLDocument sedmlDoc = createSedml(fskObj);
+      SEDMLDocument sedmlDoc = createSedml(fskObj, scriptHandler);
 
       File tempFile = FileUtil.createTempFile("sim", "");
       sedmlDoc.writeDocument(tempFile);
@@ -250,7 +250,7 @@ class WriterNodeModel extends NoInternalsModel {
 
     // Add simulations as parameter scripts
     for (FskSimulation sim : fskObj.simulations) {
-      addParameterScript(archive, sim, filePrefix);
+      addParameterScript(archive, sim, filePrefix, scriptHandler);
     }
 
     // TODO: THIS DOES NOT WORK IN WINDOWS: png file cant be opened without renaming the file to .svg  
@@ -270,24 +270,35 @@ class WriterNodeModel extends NoInternalsModel {
   }
 
   private static void writeCombinedObject(CombinedFskPortObject fskObj, CombineArchive archive,
-      Map<String, URI> URIS, String filePrefix) throws Exception {
+      Map<String, URI> URIS, String filePrefix, ScriptHandler scriptHandler) throws Exception {
     filePrefix = filePrefix + normalizeName(fskObj) + System.getProperty("file.separator");
     FskPortObject ffskObj = fskObj.getFirstFskPortObject();
-    if (ffskObj instanceof CombinedFskPortObject) {
-      writeCombinedObject((CombinedFskPortObject) ffskObj, archive, URIS, filePrefix);
-    } else {
-      writeFSKObject(ffskObj, archive,
-          filePrefix + normalizeName(ffskObj) + System.getProperty("file.separator"), URIS);
-    }
+    try (ScriptHandler singleScriptHandler = ScriptHandler
+            .createHandler(SwaggerUtil.getLanguageWrittenIn(ffskObj.modelMetadata), ffskObj.packages)) {
 
-    FskPortObject sfskObj = fskObj.getSecondFskPortObject();
-    if (sfskObj instanceof CombinedFskPortObject) {
-      writeCombinedObject((CombinedFskPortObject) sfskObj, archive, URIS, filePrefix);
-    } else {
-      writeFSKObject(sfskObj, archive,
-          filePrefix + normalizeName(sfskObj) + System.getProperty("file.separator"), URIS);
+	    if (ffskObj instanceof CombinedFskPortObject) {
+	      writeCombinedObject((CombinedFskPortObject) ffskObj, archive, URIS, filePrefix, singleScriptHandler);
+	    } else {
+	      writeFSKObject(ffskObj, archive,
+	          filePrefix + normalizeName(ffskObj) + System.getProperty("file.separator"), URIS, singleScriptHandler);
+	    }
+    } catch (Exception e) {
+    	throw new Exception(e.getLocalizedMessage(), e);
     }
     
+    FskPortObject sfskObj = fskObj.getSecondFskPortObject();
+    try (ScriptHandler singleScriptHandler = ScriptHandler
+            .createHandler(SwaggerUtil.getLanguageWrittenIn(sfskObj.modelMetadata), sfskObj.packages)) {
+
+	    if (sfskObj instanceof CombinedFskPortObject) {
+	      writeCombinedObject((CombinedFskPortObject) sfskObj, archive, URIS, filePrefix, singleScriptHandler);
+	    } else {
+	      writeFSKObject(sfskObj, archive,
+	          filePrefix + normalizeName(sfskObj) + System.getProperty("file.separator"), URIS, singleScriptHandler);
+	    }
+    } catch (Exception e) {
+        throw new Exception(e.getLocalizedMessage(), e);
+    }
     // Adds R workspace file
     if (fskObj.getWorkspace() != null) {
       addWorkspace(archive, fskObj.getWorkspace(), filePrefix);
@@ -297,7 +308,7 @@ class WriterNodeModel extends NoInternalsModel {
     addMetaData(archive, fskObj.modelMetadata, filePrefix + "metaData.json");
     // Add combined simulations
     {
-      SEDMLDocument sedmlDoc = createSedml(fskObj);
+      SEDMLDocument sedmlDoc = createSedml(fskObj, scriptHandler);
 
       File tempFile = FileUtil.createTempFile("sim", "");
       sedmlDoc.writeDocument(tempFile);
@@ -311,48 +322,51 @@ class WriterNodeModel extends NoInternalsModel {
 
     FskPortObject in = (FskPortObject) inObjects[0];
     
-    scriptHandler = ScriptHandler.createHandler(SwaggerUtil.getLanguageWrittenIn(in.modelMetadata),
-        in.packages);
-    URL url = FileUtil.toURL(filePath.getStringValue());
-    File localPath = FileUtil.getFileFromURL(url);
-
-    if (localPath != null) {
-      localPath.delete();
-      writeArchive(localPath, in, exec);
-    } else {
-
-      // Creates archive in temporary archive file
-      File archiveFile = FileUtil.createTempFile("model", "fskx");
-
-      // The file is deleted since we need the path only for the COMBINE archive
-      archiveFile.delete();
-
-      // Writes COMBINE archive
-      writeArchive(archiveFile, in, exec);
-
-      // Copies temporary file to output stream
-      try (OutputStream os = FileUtil.openOutputConnection(url, "PUT").getOutputStream()) {
-        Files.copy(archiveFile.toPath(), os);
-      }
-
-      // Deletes temporary file
-      archiveFile.delete();
+    try (ScriptHandler scriptHandler = ScriptHandler
+            .createHandler(SwaggerUtil.getLanguageWrittenIn(in.modelMetadata), in.packages)) {
+        
+	    URL url = FileUtil.toURL(filePath.getStringValue());
+	    File localPath = FileUtil.getFileFromURL(url);
+	
+	    if (localPath != null) {
+	      localPath.delete();
+	      writeArchive(localPath, in, exec, scriptHandler);
+	    } else {
+	
+	      // Creates archive in temporary archive file
+	      File archiveFile = FileUtil.createTempFile("model", "fskx");
+	
+	      // The file is deleted since we need the path only for the COMBINE archive
+	      archiveFile.delete();
+	
+	      // Writes COMBINE archive
+	      writeArchive(archiveFile, in, exec, scriptHandler);
+	
+	      // Copies temporary file to output stream
+	      try (OutputStream os = FileUtil.openOutputConnection(url, "PUT").getOutputStream()) {
+	        Files.copy(archiveFile.toPath(), os);
+	      }
+	
+	      // Deletes temporary file
+	      archiveFile.delete();
+	    }
+    } catch(Exception e) {
+        throw new Exception(e.getLocalizedMessage(), e);
     }
-
     return new PortObject[] {};
   }
 
   private static void writeArchive(File archiveFile, FskPortObject portObject,
-      ExecutionContext exec) throws Exception {
+      ExecutionContext exec, ScriptHandler scriptHandler) throws Exception {
 
     Map<String, URI> URIS = FSKML.getURIS(1, 0, 12);
 
     try (final CombineArchive archive = new CombineArchive(archiveFile)) {
 
       if (portObject instanceof CombinedFskPortObject) {
-        writeCombinedObject((CombinedFskPortObject) portObject, archive, URIS, "");
+        writeCombinedObject((CombinedFskPortObject) portObject, archive, URIS, "", scriptHandler);
       } else {
-        writeFSKObject(portObject, archive, "", URIS);
+        writeFSKObject(portObject, archive, "", URIS, scriptHandler);
       }
 
       // Add SBML document
@@ -590,7 +604,7 @@ class WriterNodeModel extends NoInternalsModel {
   }
 
   private static ArchiveEntry addRScript(final CombineArchive archive, final String script,
-      final String filename) throws IOException, URISyntaxException {
+      final String filename, ScriptHandler scriptHandler) throws IOException, URISyntaxException {
 
     final File file = File.createTempFile("temp", ".r");
     FileUtils.writeStringToFile(file, script, "UTF-8");
@@ -638,7 +652,7 @@ class WriterNodeModel extends NoInternalsModel {
 
 
 
-  private static SEDMLDocument createSedml(FskPortObject portObj) {
+  private static SEDMLDocument createSedml(FskPortObject portObj, ScriptHandler scriptHandler) {
 
     SEDMLDocument doc = Libsedml.createDocument();
     SedML sedml = doc.getSedMLModel();
@@ -746,7 +760,7 @@ class WriterNodeModel extends NoInternalsModel {
 
 
   private static void addParameterScript(CombineArchive archive, FskSimulation simulation,
-      String filePrefix) throws IOException {
+      String filePrefix, ScriptHandler scriptHandler) throws IOException {
 
     String script = scriptHandler.buildParameterScript(simulation);
 

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
@@ -206,7 +206,8 @@ public class RScriptHandler extends ScriptHandler {
   @Override
   public void close() throws Exception {
     RprofileManager.unSubscribe();
-    controller.close();
+    //controller.close();
+    controller.terminateRProcess();
   }
 
   @Override

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
@@ -206,8 +206,7 @@ public class RScriptHandler extends ScriptHandler {
   @Override
   public void close() throws Exception {
     RprofileManager.unSubscribe();
-    //controller.close();
-    controller.terminateRProcess();
+    controller.close();
   }
 
   @Override

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
@@ -39,6 +39,8 @@ public class RScriptHandler extends ScriptHandler {
 
   public RScriptHandler(List<String> packages) throws RException, IOException {
     RprofileManager.subscribe();
+    // initialize LibRegistry before Controller to avoid errors on switching R in preferences
+    LibRegistry.instance(); 
     this.controller = new RController();
     this.executor = new ScriptExecutor(controller);
 

--- a/de.bund.bfr.knime.fsklab.preferences/src/de/bund/bfr/knime/fsklab/preferences/PreferencePage.java
+++ b/de.bund.bfr.knime.fsklab.preferences/src/de/bund/bfr/knime/fsklab/preferences/PreferencePage.java
@@ -87,8 +87,9 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 			}
 
 			try {
+				PreferenceInitializer.refresh = false;
 				RBinUtil.checkRHome(rHome, true);
-
+				
 				DefaultRPreferenceProvider prefProvider = new DefaultRPreferenceProvider(rHome);
 				final Properties props = prefProvider.getProperties();
 				// the version numbers may contain spaces
@@ -132,7 +133,7 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 						return false;
 					}
 				}
-
+				PreferenceInitializer.refresh = true;
 				setMessage(null, NONE);
 				return true;
 			} catch (InvalidRHomeException e) {

--- a/de.bund.bfr.knime.fsklab.preferences/src/de/bund/bfr/knime/fsklab/preferences/RBinUtil.java
+++ b/de.bund.bfr.knime.fsklab.preferences/src/de/bund/bfr/knime/fsklab/preferences/RBinUtil.java
@@ -109,7 +109,7 @@ public class RBinUtil {
 	 * @return properties about used R
 	 */
 	public static Properties retrieveRProperties(final RPreferenceProvider rpref) {
-        PreferenceInitializer.refresh = true;
+        
 		final File tmpPath = new File(TEMP_PATH);
 		File propsFile;
 		File rOutFile;

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
@@ -136,7 +136,8 @@ public class LibRegistry {
 
   public synchronized static LibRegistry instance() throws IOException, RException {
     if (instance == null || PreferenceInitializer.refresh) {
-      instance = new LibRegistry();
+      if(instance == null)
+    	instance = new LibRegistry();
       PreferenceInitializer.refresh = false;
     }
     return instance;

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
@@ -109,17 +109,7 @@ public class LibRegistry {
       String[] pkgArray = installPath.toFile().list();
       installedLibs = Arrays.stream(pkgArray).collect(Collectors.toSet());
 
-      // Remove libraries, that are technically installed but with an incompatible version to avoid trouble during execution
-      /*installedLibs.removeIf(
-          lib ->{
-            try {
-              controller.eval("library("+ lib + ")", true);
-              return false;
-            }catch(Exception e) {
-              return true;
-            }
-          });
-          */
+
     } else {
 
       // Create directories

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
@@ -110,7 +110,7 @@ public class LibRegistry {
       installedLibs = Arrays.stream(pkgArray).collect(Collectors.toSet());
 
       // Remove libraries, that are technically installed but with an incompatible version to avoid trouble during execution
-      installedLibs.removeIf(
+      /*installedLibs.removeIf(
           lib ->{
             try {
               controller.eval("library("+ lib + ")", true);
@@ -119,6 +119,7 @@ public class LibRegistry {
               return true;
             }
           });
+          */
     } else {
 
       // Create directories
@@ -135,9 +136,8 @@ public class LibRegistry {
   }
 
   public synchronized static LibRegistry instance() throws IOException, RException {
-    if (instance == null || PreferenceInitializer.refresh) {
-      if(instance == null)
-    	instance = new LibRegistry();
+    if (instance == null ) {
+      instance = new LibRegistry();
       PreferenceInitializer.refresh = false;
     }
     return instance;

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
@@ -42,6 +42,7 @@ import org.rosuda.REngine.RList;
 import com.sun.jna.Platform;
 import de.bund.bfr.knime.fsklab.preferences.PreferenceInitializer;
 import de.bund.bfr.knime.fsklab.r.client.IRController.RException;
+import de.bund.bfr.knime.fsklab.r.server.RConnectionFactory.RConnectionResource;
 
 /**
  * Singleton!! There can only be one.
@@ -140,8 +141,8 @@ public class LibRegistry {
 	  synchronized(instance) {
 		  try {
 			  instance.controller.close();
-			  //Thread.sleep(15000);
-			  instance.wait(15000);
+			  // Wait until controller is actually closed. 
+			  instance.wait(RConnectionResource.RPROCESS_TIMEOUT + 2000);
 			  instance = new LibRegistry();
 		  } catch(Exception e) {
 			  instance = null;

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
@@ -126,20 +126,30 @@ public class LibRegistry {
   }
 
   public synchronized static LibRegistry instance() throws IOException, RException {
-    if (instance == null || PreferenceInitializer.refresh ) {
-    	PreferenceInitializer.refresh = false;
-//    	if(instance != null) {
-//    		instance.controller.close();
-//    		instance = null;
-//    	}
-    	
-    	instance = new LibRegistry();
-    	
-    }
-   
-    return instance;
+    
+	  if(PreferenceInitializer.refresh)
+		  refreshInstance();
+	  if (instance == null ) {
+		  instance = new LibRegistry();
+	  }
+
+	  return instance;
   }
 
+  private static void refreshInstance() {
+	  synchronized(instance) {
+		  try {
+			  instance.controller.close();
+			  //Thread.sleep(15000);
+			  instance.wait(15000);
+			  instance = new LibRegistry();
+		  } catch(Exception e) {
+			  instance = null;
+		  } finally {
+			  PreferenceInitializer.refresh = false;
+		  }
+	  }
+  }
   /**
    * Install a list of packages into the repository. Already installed packages
    * are ignored.

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
@@ -62,7 +62,7 @@ public class LibRegistry {
   private final Set<String> installedLibs;
 
   /** Utility RController for running R commands. */
-  private final RController controller = new RController();
+  public final RController controller = new RController();
 
   private String type;
 
@@ -71,7 +71,7 @@ public class LibRegistry {
   private final String MIRROR = "https://cran.rstudio.com";
 
   private LibRegistry() throws IOException, RException {
-
+	  
     if (Platform.isWindows()) {
       type = "win.binary";
     } else if (Platform.isMac()) {
@@ -126,10 +126,17 @@ public class LibRegistry {
   }
 
   public synchronized static LibRegistry instance() throws IOException, RException {
-    if (instance == null ) {
-      instance = new LibRegistry();
-      PreferenceInitializer.refresh = false;
+    if (instance == null || PreferenceInitializer.refresh ) {
+    	PreferenceInitializer.refresh = false;
+//    	if(instance != null) {
+//    		instance.controller.close();
+//    		instance = null;
+//    	}
+    	
+    	instance = new LibRegistry();
+    	
     }
+   
     return instance;
   }
 

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/RController.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/RController.java
@@ -239,7 +239,7 @@ public class RController implements IRController {
   /**
    * Terminate the R process started for this RController.
    */
-  public synchronized void terminateRProcess() {
+  private synchronized void terminateRProcess() {
     if (m_connection != null) {
       m_connection.destroy(true);
       m_connection = null;

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/RController.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/RController.java
@@ -239,7 +239,7 @@ public class RController implements IRController {
   /**
    * Terminate the R process started for this RController.
    */
-  private synchronized void terminateRProcess() {
+  public synchronized void terminateRProcess() {
     if (m_connection != null) {
       m_connection.destroy(true);
       m_connection = null;

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/server/RConnectionFactory.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/server/RConnectionFactory.java
@@ -536,7 +536,7 @@ public class RConnectionFactory {
 		private RInstance m_instance;
 		private TimerTask m_pendingDestructionTask = null;
 
-		private static final int RPROCESS_TIMEOUT = 60000;
+		private static final int RPROCESS_TIMEOUT = 100;
 
 		/**
 		 * Constructor

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/server/RConnectionFactory.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/server/RConnectionFactory.java
@@ -536,7 +536,7 @@ public class RConnectionFactory {
 		private RInstance m_instance;
 		private TimerTask m_pendingDestructionTask = null;
 
-		private static final int RPROCESS_TIMEOUT = 10000;
+		public static final int RPROCESS_TIMEOUT = 10000;
 
 		/**
 		 * Constructor

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/server/RConnectionFactory.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/server/RConnectionFactory.java
@@ -536,7 +536,7 @@ public class RConnectionFactory {
 		private RInstance m_instance;
 		private TimerTask m_pendingDestructionTask = null;
 
-		private static final int RPROCESS_TIMEOUT = 100;
+		private static final int RPROCESS_TIMEOUT = 10000;
 
 		/**
 		 * Constructor


### PR DESCRIPTION
- There was a library check that tested each library if it is valid and that blew up the Rserve workspace everytime a model was running. With our new Rprofile implementation, that is now completely superfluous.
- More important, a new LibRegistry instance (and therefore a new RController) was created every time a Runner was executed. That meant, the old instance was not shut down properly. It is now ensured, that only one LibRegistry is open while needed.
- Also, each Rserve instance is now almost immeadiatly closed after executon (100ms). The 60000ms might have been useful for KNIME's R integration but we don't need that.

This massively improves memory management without changing too much of the code. 