### PR TITLE
Improve json handling

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes.common/src/de/bund/bfr/knime/fsklab/nodes/plot/Ggplot2Plotter.java
+++ b/de.bund.bfr.knime.fsklab.nodes.common/src/de/bund/bfr/knime/fsklab/nodes/plot/Ggplot2Plotter.java
@@ -42,7 +42,9 @@ public class Ggplot2Plotter implements ModelPlotter {
     // Get image path (with proper slashes)
     final String path = FilenameUtils.separatorsToUnix(file.getAbsolutePath());
 
-    final String wholeScript = "require(\"ggplot2\")"+script + "\nggsave('" + path + "', width = 4, height = 4)";
-    controller.eval(wholeScript, false);
+    controller.eval("require(ggplot2)", false);
+    controller.eval(script, false);
+    controller.eval("ggsave('" + path + "')", false);// removed size width=4, height=4
+    
   }
 }

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/JsonHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/JsonHandler.java
@@ -1,6 +1,7 @@
 package de.bund.bfr.knime.fsklab.nodes;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -88,7 +89,7 @@ public abstract class JsonHandler {
       // work through Map
       for (Map.Entry<String, List<JoinerObject>> entry : sourceTargetPathMap.entrySet()) {
         //ParameterData parameterData = MAPPER.readValue(new File(jsonPath), ParameterData.class);
-        ParameterData parameterData = MAPPER.readValue(new File(entry.getKey()), ParameterData.class);
+        ParameterData parameterData = MAPPER.readValue(new FileInputStream(entry.getKey()), ParameterData.class);
         for (JoinerObject obj : entry.getValue()) {
           loadParametersIntoWorkspace(parameterData, obj.sourceParameter, obj.targetParameter.getId());
 

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/JsonHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/JsonHandler.java
@@ -83,8 +83,8 @@ public abstract class JsonHandler {
 //TODO: check what happens if sourceTargetPathMap is empty
       // work through Map, each entry is a parameters.json file, load data into workspace
       for (Map.Entry<String, List<JoinerObject>> entry : sourceTargetPathMap.entrySet()) {
-        //ParameterData parameterData = MAPPER.readValue(new File(jsonPath), ParameterData.class);
-        ParameterData parameterData = MAPPER.readValue(new FileInputStream(entry.getKey()), ParameterData.class);
+        ParameterData parameterData = MAPPER.readValue(new File(entry.getKey()), ParameterData.class);
+        //ParameterData parameterData = MAPPER.readValue(new FileInputStream(entry.getKey()), ParameterData.class);
         for (JoinerObject obj : entry.getValue()) {
           loadParametersIntoWorkspace(parameterData, obj.sourceParameter, obj.targetParameter.getId());
 

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/JsonHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/JsonHandler.java
@@ -57,11 +57,13 @@ public abstract class JsonHandler {
     }
   }
 
-  // TODO: conversion command? maybe create a new Class instead of using a map
+  // Method loads parameter data from previous models into workspace of current model
+  // according to the list of Joiner-Relations
   public void applyJoinRelation(FskPortObject fskObj, List<JoinRelationAdvanced> joinRelationList,
       String suffix) throws Exception {
 
-
+    // figure out which parameters from JoinRelations belong to which model to avoid loading
+    // a json file twice
     if (joinRelationList != null) {
       // get all relevant parameters -> assign to Map with key=jsonPath
       Map<String, List<JoinerObject>> sourceTargetPathMap = new HashMap();
@@ -86,7 +88,7 @@ public abstract class JsonHandler {
       }// for joinRelation
 
 
-      // work through Map
+      // work through Map, each entry is a parameters.json file, load data into workspace
       for (Map.Entry<String, List<JoinerObject>> entry : sourceTargetPathMap.entrySet()) {
         //ParameterData parameterData = MAPPER.readValue(new File(jsonPath), ParameterData.class);
         ParameterData parameterData = MAPPER.readValue(new FileInputStream(entry.getKey()), ParameterData.class);
@@ -108,11 +110,12 @@ public abstract class JsonHandler {
     }// if     
   }
 
+  // helper class to keep track of which list of Joiner-Relations is related to which parameter.json file
   private class JoinerObject{
     public String sourceParameter;
     public Parameter targetParameter;
     public JoinRelationAdvanced joinRelation;
-    public String resourcePath;
+    public String resourcePath; // path to parameter.json file
     public JoinerObject(String source, Parameter target, JoinRelationAdvanced relation, String path) {
       sourceParameter = source;
       targetParameter = target;

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/PythonJsonHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/PythonJsonHandler.java
@@ -114,13 +114,12 @@ public class PythonJsonHandler extends JsonHandler {
    * @throws Exception
    */
   @Override
-  public void loadParametersIntoWorkspace(String parameterJson, String sourceParam,
+  public void loadParametersIntoWorkspace(ParameterData parameterData, String sourceParam,
       String targetParam) throws Exception {
 
     // StringBuilder script = new StringBuilder();
 
-    // load source and target into workspace as strings
-    ParameterData parameterData = MAPPER.readValue(new File(parameterJson), ParameterData.class);
+        
     
     for (DataArray param : parameterData.getParameters()) {
       if (sourceParam.equals(param.getMetadata().getId())) {

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RJsonHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RJsonHandler.java
@@ -120,6 +120,7 @@ public class RJsonHandler extends JsonHandler {
     }
     String path = workingDirectory.toString() + File.separator + JSON_FILE_NAME;
     MAPPER.writer().writeValue(new File(path), parameterJson);
+    //parameterJson = null;
   }
 
 
@@ -131,10 +132,10 @@ public class RJsonHandler extends JsonHandler {
    * @throws Exception
    */
   @Override
-  public void loadParametersIntoWorkspace(String parameterJson, String sourceParam,
+  public void loadParametersIntoWorkspace(ParameterData parameterData, String sourceParam,
       String targetParam) throws Exception {
 
-    ParameterData parameterData = MAPPER.readValue(new File(parameterJson), ParameterData.class);
+    
     
     for (DataArray param : parameterData.getParameters()) {
       if (sourceParam.equals(param.getMetadata().getId())) {

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
@@ -126,7 +126,7 @@ public class RScriptHandler extends ScriptHandler {
       LibRegistry.instance().install(fskObj.packages);
     }
 
-    exec.setProgress(0.71, "Add paths to libraries");
+    exec.setProgress(0.2, "Add paths to libraries");
     controller.addPackagePath(LibRegistry.instance().getInstallationPath());
   }
 

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
@@ -2,8 +2,10 @@ package de.bund.bfr.knime.fsklab.nodes;
 
 import de.bund.bfr.knime.fsklab.nodes.plot.BasePlotter;
 import de.bund.bfr.knime.fsklab.nodes.plot.Ggplot2Plotter;
+import de.bund.bfr.knime.fsklab.preferences.PreferenceInitializer;
 import de.bund.bfr.knime.fsklab.r.client.IRController.RException;
 import de.bund.bfr.knime.fsklab.r.client.LibRegistry;
+import de.bund.bfr.knime.fsklab.r.client.LibRegistry.NoInternetException;
 import de.bund.bfr.knime.fsklab.r.client.RController;
 import de.bund.bfr.knime.fsklab.r.client.RprofileManager;
 import de.bund.bfr.knime.fsklab.r.client.ScriptExecutor;
@@ -123,7 +125,17 @@ public class RScriptHandler extends ScriptHandler {
       throws Exception {
     // Install needed libraries
     if (!fskObj.packages.isEmpty()) {
-      LibRegistry.instance().install(fskObj.packages);
+      // surround with try catch, 
+      // in case LibRegistry controller is somehow closed, refresh on fail 
+      // (this happens, if a library is not successfully installed by FSK-Lab but then
+      // installed by user themselves (or Rserve instance is closed by other means)
+      try {
+        LibRegistry.instance().install(fskObj.packages);  
+      } catch ( RException| REXPMismatchException | NoInternetException e) {
+        PreferenceInitializer.refresh = true;
+        LibRegistry.instance().install(fskObj.packages);
+      }
+      
     }
 
     exec.setProgress(0.2, "Add paths to libraries");

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
@@ -87,11 +87,16 @@ public abstract class ScriptHandler implements AutoCloseable {
     exec.setProgress(0.3, "create JsonHandler");
     jsonHandler = JsonHandler.createHandler(this, exec);
     exec.setProgress(0.4, "apply Join Relations");
+
+    // Performance Test: how long to load json data into workspace
     Instant start = Instant.now();
     jsonHandler.applyJoinRelation(fskObj, joinRelationList, suffix);
     Instant end = Instant.now();
-    Duration timeElapsed = Duration.between(start, end); 
-    logger.warn("elapsed time: "+timeElapsed.getSeconds() + "s\n" );
+    Duration timeElapsed = Duration.between(start, end);
+    if(saveToJsonChecked) {
+      logger.warn("time to load json file into workspace: "+timeElapsed.getSeconds() + "s\n" );  
+    }
+    
 
    
 

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
@@ -82,8 +82,9 @@ public abstract class ScriptHandler implements AutoCloseable {
     // Install needed libraries & set path to .fsk folder
     installLibs(fskObj, exec, logger);
     
-
+    exec.setProgress(0.3, "create JsonHandler");
     jsonHandler = JsonHandler.createHandler(this, exec);
+    exec.setProgress(0.4, "apply Join Relations");
     jsonHandler.applyJoinRelation(fskObj, joinRelationList, suffix);
 
 
@@ -152,6 +153,17 @@ public abstract class ScriptHandler implements AutoCloseable {
     } catch (final Exception exception) {
       logger.warn("Visualization script failed", exception);
     }
+    
+    // HDFHandler stores all ouput parameters in HDF file
+    if(saveToJsonChecked) {
+      exec.setProgress(0.92, "Save output parameters");
+      jsonHandler.saveOutputParameters(fskObj, workingDirectory);
+    }
+      
+
+    // Save generated resources
+    exec.setProgress(0.92, "Save generated resources");
+    saveGeneratedResources(fskObj, workingDirectory.toFile(), exec.createSubExecutionContext(1));
 
     exec.setProgress(0.96, "Restore library paths");
     restoreDefaultLibrary();
@@ -161,14 +173,6 @@ public abstract class ScriptHandler implements AutoCloseable {
 
     saveWorkspace(fskObj, exec);
 
-    // HDFHandler stores all ouput parameters in HDF file
-    if(saveToJsonChecked) {
-      jsonHandler.saveOutputParameters(fskObj, workingDirectory);
-    }
-      
-
-    // Save generated resources
-    saveGeneratedResources(fskObj, workingDirectory.toFile(), exec.createSubExecutionContext(1));
 
   
 

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -85,8 +87,13 @@ public abstract class ScriptHandler implements AutoCloseable {
     exec.setProgress(0.3, "create JsonHandler");
     jsonHandler = JsonHandler.createHandler(this, exec);
     exec.setProgress(0.4, "apply Join Relations");
+    Instant start = Instant.now();
     jsonHandler.applyJoinRelation(fskObj, joinRelationList, suffix);
+    Instant end = Instant.now();
+    Duration timeElapsed = Duration.between(start, end); 
+    logger.warn("elapsed time: "+timeElapsed.getSeconds() + "s\n" );
 
+   
 
     exec.setProgress(0.72, "Set parameter values");
     logger.info(" Running with '" + simulation.getName() + "' simulation!");

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/runner/RunnerNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/runner/RunnerNodeModel.java
@@ -244,7 +244,9 @@ public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjec
       // create a parameter.json for the top level combined model
       return new PortObject[] {fskObj, imgObj};
     } catch (IOException e) {
+      
       LOGGER.warn("There is no image created");
+      LOGGER.warn(e.getMessage());
       return new PortObject[] {fskObj};
     }
   }
@@ -405,12 +407,12 @@ public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjec
     if (portObject.getJoinerRelation() != null) {
       joinRelations.addAll(Arrays.asList(portObject.getJoinerRelation()));
     }
-    if (portObject.getFirstFskPortObject() instanceof CombinedFskPortObject) {
-      getJoinRelations((CombinedFskPortObject) portObject.getFirstFskPortObject(), joinRelations);
-    }
-    if (portObject.getSecondFskPortObject() instanceof CombinedFskPortObject) {
-      getJoinRelations((CombinedFskPortObject) portObject.getSecondFskPortObject(), joinRelations);
-    }
+//    if (portObject.getFirstFskPortObject() instanceof CombinedFskPortObject) {
+//      getJoinRelations((CombinedFskPortObject) portObject.getFirstFskPortObject(), joinRelations);
+//    }
+//    if (portObject.getSecondFskPortObject() instanceof CombinedFskPortObject) {
+//      getJoinRelations((CombinedFskPortObject) portObject.getSecondFskPortObject(), joinRelations);
+//    }
 
     return joinRelations;
   }

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
@@ -128,11 +128,13 @@ public class LibRegistry {
 
   public synchronized static LibRegistry instance() throws IOException, RException {
     
-	  if(PreferenceInitializer.refresh)
-		  refreshInstance();
 	  if (instance == null ) {
 		  instance = new LibRegistry();
+		  PreferenceInitializer.refresh = false;
 	  }
+	  if(PreferenceInitializer.refresh)
+		  refreshInstance();
+	  
 
 	  return instance;
   }


### PR DESCRIPTION
When a model creates parameter data during execution, it used to be stored in a java object to be serialized later into a parameters.json file. This was memory inefficient, so the parameter data for a combined model is now streamed into a file directly without holding it in an object.
This will be done for single models as well, but in a later PR.

Also: 
- JsonHandler.applyJoinRelation was improved to only open a parameters.json file once instead of multiple times.
- Ggplot2Plotter had a weird size limit of the plot (4x4), which lead to cropped images. Now there is no size limit.
- Ggplot2Plotter also was bugging out if "import(ggplot2)" was written somewhere in the model script. Now it seems to be working (not related to https://github.com/RakipInitiative/ModelRepository/issues/330)
- LibRegistry had a nullPointerException bug when a user switches the R installation before running a model with the bundled R.
- Sometimes there was a an issue with R packages not getting installed which lead to LibRegistry killing the Rserve Controller and preventing subsequent Controllers from installing packages. This was changed in RScripthandler.installLibs where an unsuccessful installation will lead to creating a new LibRegistry with a new controller.

The PR can best be tested with knime://external-KNIME-Server/FSKX_Testing/FSK-Lab_2.0/broken_workflows/Joining_TrichinellaModels