### PR TITLE
fixed bug, where on empty search result table would still show models

### DIFF
--- a/de.bund.bfr.knime.js/src/js/app/app.table.mt.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.table.mt.js
@@ -497,6 +497,10 @@ class APPTableMT extends APPTable {
 				// match = true : will be shown
 				let rowMatchesFilter = true;
 
+				// if search result is empty, no match was found
+				if( searchResult.length == 0) {
+					rowMatchesFilter = false;
+				} 
 				// filter by search
 				if( searchResult.length > 0 
 					&& ! searchResult.includes( rowIndex ) ) {


### PR DESCRIPTION
landingpage bugfix, related to the request of @mfilter where on a search with no hits, the model repository would still show all models.