### PR TITLE
editor always creates a minimum viable model for basic FSK nodes

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
@@ -468,8 +468,7 @@ final class FSKEditorJSNodeModel
         if(originalParameters != null)
           checkAndRegenerateSimulation(simulations, originalParameters, parameters);
 
-      }
-      else if (metadata != null && SwaggerUtil.getModelMath(metadata) != null
+      } else if (metadata != null && SwaggerUtil.getModelMath(metadata) != null
           && SwaggerUtil.getParameter(metadata) != null)  {
 
         // 1. Create new default simulation out of the view value
@@ -483,7 +482,7 @@ final class FSKEditorJSNodeModel
         // is not opened
         FskSimulation newDefaultSimulation = NodeUtils.createDefaultSimulation(parameters);
         simulations = Arrays.asList(newDefaultSimulation);
-        
+
       }
 
       modelScript = StringUtils.defaultString(viewValue.getModelScript(), "");

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSNodeModel.java
@@ -468,7 +468,8 @@ final class FSKEditorJSNodeModel
         if(originalParameters != null)
           checkAndRegenerateSimulation(simulations, originalParameters, parameters);
 
-      }else if (metadata != null && SwaggerUtil.getModelMath(metadata) != null
+      }
+      else if (metadata != null && SwaggerUtil.getModelMath(metadata) != null
           && SwaggerUtil.getParameter(metadata) != null)  {
 
         // 1. Create new default simulation out of the view value
@@ -476,6 +477,13 @@ final class FSKEditorJSNodeModel
 
         // 2. Assign newDefaultSimulation
         simulations = Arrays.asList(newDefaultSimulation);
+      } else if(metadata == null) {
+
+        // Make sure at least a default simulation is present at any time, even if editor view
+        // is not opened
+        FskSimulation newDefaultSimulation = NodeUtils.createDefaultSimulation(parameters);
+        simulations = Arrays.asList(newDefaultSimulation);
+        
       }
 
       modelScript = StringUtils.defaultString(viewValue.getModelScript(), "");

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/writer/WriterNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/writer/WriterNodeModel.java
@@ -557,7 +557,9 @@ class WriterNodeModel extends NoInternalsModel {
   }
 
   public static String normalizeName(FskPortObject fskObj) {
-    return SwaggerUtil.getModelName(fskObj.modelMetadata).replaceAll("\\W", "").replace(" ", "");
+    if(SwaggerUtil.getModelName(fskObj.modelMetadata) != null)
+      return SwaggerUtil.getModelName(fskObj.modelMetadata).replaceAll("\\W", "").replace(" ", "");
+    return "noModelName";
   }
 
   private static SBMLDocument createSBML(FskPortObject fskObj, CombineArchive archive,


### PR DESCRIPTION
- changed Editor to apply an empty defaultSimulation
- changed Writer to accept model without name
- https://github.com/RakipInitiative/ModelRepository/issues/352