### PR TITLE
fixed bug in writer regarding model names starting with number

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/writer/WriterNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/writer/WriterNodeModel.java
@@ -557,11 +557,18 @@ class WriterNodeModel extends NoInternalsModel {
   }
 
   public static String normalizeName(FskPortObject fskObj) {
-    if(SwaggerUtil.getModelName(fskObj.modelMetadata) != null)
-      return "_" + SwaggerUtil.getModelName(fskObj.modelMetadata)
-          .replaceAll("[^a-zA-Z0-9_]", "")
+    String name = "noModelName";
+    if(SwaggerUtil.getModelName(fskObj.modelMetadata) != null) {
+      name = SwaggerUtil.getModelName(fskObj.modelMetadata)
+          .replaceAll("[^a-zA-Z0-9_]", "") // remove everything not char,number or _
           .replace(" ", "");
-    return "noModelName";
+      //if name starts with number, remove it
+      while (name.matches("^[0-9].*$")) {
+        name = name.substring(1);
+      }
+      
+    }
+    return name;
   }
 
   private static SBMLDocument createSBML(FskPortObject fskObj, CombineArchive archive,


### PR DESCRIPTION
If a model name starts with a number and is joined, the writer would use
that name to create an SBML id. Since that id is not allowed to start
with a number, the id is cleaned up before writing the model.