### PR TITLE
fixes forced rounding in Simulation Configurator node

### DIFF
--- a/de.bund.bfr.knime.js/src/js/app/app.simulation.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.simulation.js
@@ -334,7 +334,7 @@ class APPSimulation {
 						let step = 1;
 						// calc decimals for slider steps depending on min-max values
 						if ( param.dataType.toLowerCase() === 'double' ) {
-							let decimals = Math.max( param.minValue.substring( param.minValue.indexOf( '.' ) + 1 ).length, param.maxValue.substring( param.maxValue.indexOf( '.' ) + 1 ).length );
+							let decimals = param.value.substring(param.value.indexOf('.') + 1).length;
 							for ( let j = 0; j < decimals; j++ ) {
 								step = step / 10;
 							}

--- a/de.bund.bfr.knime.js/src/js/app/app.ui.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.ui.js
@@ -137,7 +137,14 @@ class APPUI {
 		return $alert;
 	}
 
-
+	_precision(param) {
+		let step = 1;
+	  	let decimals = param.substring(param.indexOf('.') + 1).length;
+		for ( let j = 0; j < decimals; j++ ) {
+			step = step / 10;
+		}
+	  	return step;
+	}
 	/**
 	 * POPULATE SELECT
 	 *
@@ -551,7 +558,8 @@ class APPUI {
 						}
 
 						$el.data( 'rangeslider' ).update( {
-							from : val
+							from : val,
+							step: O._precision(val)
 						} );
 
 						$el.$inputSingle.val( val );


### PR DESCRIPTION
when parameter has min and max values, new values are now no longer
rounded to initial value when the user chooses to increase precision.
Example: value = 0.4 -> User changes value to 0.04 -> Value is no longer
rounded to 0.0 (like before).