### PR TITLE
tidyverse not recognized as ggplot

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes.common/src/de/bund/bfr/knime/fsklab/nodes/plot/BasePlotter.java
+++ b/de.bund.bfr.knime.fsklab.nodes.common/src/de/bund/bfr/knime/fsklab/nodes/plot/BasePlotter.java
@@ -34,6 +34,16 @@ public class BasePlotter implements ModelPlotter {
     controller.eval(pngCommand, false);
     controller.eval(script, false);
     controller.eval("dev.off()", false);
+    // if image is empty, try with print(last_plot())
+    // this happens in rserve, if a plot is not explicitly printed
+    // (e.g. when the ggplot function is stored in a variable
+    // however, the last_plot() really only prints the very last plot
+    // thus omitting any previous ones, therefore this zig-zagging
+    if(file.length() < 1000) {
+    	controller.eval("png('" + path + "')", false);
+    	controller.eval(script, false);
+    	controller.eval("print(last_plot());dev.off()", false);
+    }
   }
 
   @Override
@@ -50,5 +60,15 @@ public class BasePlotter implements ModelPlotter {
     final String wholeScript =
         String.join("\n", configCmd, "svg('" + path + "')", script, "dev.off()");
     controller.eval(wholeScript, false);
+    // if image is empty, try with print(last_plot())
+    // this happens in rserve, if a plot is not explicitly printed
+    // (e.g. when the ggplot function is stored in a variable
+    // however, the last_plot() really only prints the very last plot
+    // thus omitting any previous ones, therefore this zig-zagging
+    if(file.length() < 1000) {
+    	controller.eval("svg('" + path + "')", false);
+    	controller.eval(script, false);
+    	controller.eval("print(last_plot());dev.off()", false);
+    }
   }
 }

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/RScriptHandler.java
@@ -46,7 +46,7 @@ public class RScriptHandler extends ScriptHandler {
     this.controller = new RController();
     this.executor = new ScriptExecutor(controller);
 
-    if (packages.contains("ggplot2")) {
+    if (packages.contains("ggplot2") || packages.contains("tidyverse")) {
       plotter = new Ggplot2Plotter(controller);
     } else {
       plotter = new BasePlotter(controller);


### PR DESCRIPTION
if the model uses tidyverse, ggplot might be used to create the plot. In
that case, the wrong plotter (BasePlotter) class was chosen, leading to
an empty plot.