### PR TITLE
Fix for broken Sorting and Editor Nullpointer Issue 4.0

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSViewValue.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/editor/FSKEditorJSViewValue.java
@@ -97,10 +97,12 @@ class FSKEditorJSViewValue extends JSONViewContent {
     modelMetaData = settings.getString(CFG_MODEL_METADATA);
     // fix for old broken strings. Previously some strings were escaped and wrapped with
     // extra quotes at the beginning and end.
-    if (modelMetaData.startsWith("\"") && modelMetaData.endsWith("\"")) {
-      modelMetaData = StringEscapeUtils.unescapeJson(modelMetaData);
-      modelMetaData = modelMetaData.substring(1, modelMetaData.length() - 1);
-    }
+    if(modelMetaData != null) {
+      if (modelMetaData.startsWith("\"") && modelMetaData.endsWith("\"")) {
+        modelMetaData = StringEscapeUtils.unescapeJson(modelMetaData);
+        modelMetaData = modelMetaData.substring(1, modelMetaData.length() - 1);
+      }  
+    }    
 
     modelScript = settings.getString(CFG_ORIGINAL_MODEL_SCRIPT);
     visualizationScript = settings.getString(CFG_ORIGINAL_VISUALIZATION_SCRIPT);

--- a/de.bund.bfr.knime.js/src/js/app/app.table.mt.js
+++ b/de.bund.bfr.knime.js/src/js/app/app.table.mt.js
@@ -515,7 +515,7 @@ class APPTableMT extends APPTable {
 						if ( $.isArray( facetValue ) && facetValue.length > 0 ) {
 
 							// get according col index
-							let colIndex = _getColIndexByField( field );
+							let colIndex = super._getColIndexByField( field );
 							let cellData = rowData.cells[colIndex];
 
 							if( cellData instanceof Set ) {


### PR DESCRIPTION
The sorting was broken because getColIndexByField was not found. Also
fixed a NullPointerException issue when an Editor node was saved without
any inObject or without opening and saving the view.