### PR TITLE
store plot images of submodels of combined models in flow-variable

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/nodes/ScriptHandler.java
@@ -455,5 +455,19 @@ public abstract class ScriptHandler implements AutoCloseable {
     } catch (CanceledExecutionException | IOException e) {
       throw new JsonFileNotFoundException(workingDirectory.toString());
     }
+
+    // Save Plot in generatedResouces Folder (SubPlot for Combined Models)    
+    try {
+      if(fskPortObject.getPlot() != null && fskPortObject.getGeneratedResourcesDirectory().isPresent()) {
+        File sourcePlot = new File(fskPortObject.getPlot());
+        String targetPlotName =  (SwaggerUtil.getModelId(fskPortObject.modelMetadata) != null) 
+            ? SwaggerUtil.getModelId(fskPortObject.modelMetadata) + ".svg" 
+                : "subModelPlot.svg";
+        File targetPlot = new File(fskPortObject.getGeneratedResourcesDirectory().get(), targetPlotName);
+        FileUtil.copy(sourcePlot, targetPlot, exec);  
+      }
+    } catch(IOException | CanceledExecutionException e) {
+      throw new ResourceFileNotFoundException(fskPortObject.getPlot());
+    }
   }
 }

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/runner/RunnerNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/runner/RunnerNodeModel.java
@@ -65,6 +65,8 @@ import org.knime.core.node.port.PortObjectSpec;
 import org.knime.core.node.port.PortType;
 import org.knime.core.node.port.image.ImagePortObject;
 import org.knime.core.node.port.image.ImagePortObjectSpec;
+import org.knime.core.node.workflow.VariableType;
+import org.knime.core.node.workflow.VariableType.StringArrayType;
 import org.knime.core.util.FileUtil;
 
 public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjectHolder {
@@ -209,7 +211,13 @@ public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjec
       this.pushFlowVariableString("generatedResources",
           fskObj.getGeneratedResourcesDirectory().get().getAbsolutePath());
     }
-    
+    // Store subplots of Comnbined Model in Flow-Variable
+    if (fskObj instanceof CombinedFskPortObject) {
+      List<String> subPlotPaths = new ArrayList<String>();
+      makeSubPlotsAvailable(fskObj,subPlotPaths);
+      this.pushFlowVariable("SubPlots",
+          VariableType.StringArrayType.INSTANCE,subPlotPaths.toArray(new String[0]));
+    }
     if(isVisScriptEmpty(fskObj)) {
       LOGGER.warn("There is no visualization script");
       String noImage = "<?xml version=\"1.0\"?>\n"
@@ -316,7 +324,27 @@ public class RunnerNodeModel extends ExtToolOutputNodeModel implements PortObjec
     }
   }
   
-
+  public void makeSubPlotsAvailable(FskPortObject fskObj, List<String> list) {
+    
+    if (fskObj instanceof CombinedFskPortObject) {
+      makeSubPlotsAvailable(((CombinedFskPortObject) fskObj).getFirstFskPortObject(), list);
+      makeSubPlotsAvailable(((CombinedFskPortObject) fskObj).getSecondFskPortObject(), list);
+    } else {
+      if(fskObj.getGeneratedResourcesDirectory().isPresent()) {
+        try {
+          list.addAll(Files.walk(fskObj.getGeneratedResourcesDirectory().get().toPath())
+              .map(file -> file.toString()).filter(file -> file.endsWith(".svg"))
+              .collect(Collectors.toList()));
+        } catch(IOException e) {
+          String modelID = SwaggerUtil.getModelId(fskObj.modelMetadata);
+          String plotNotFoundMsg = (modelID != null) ? modelID + " generated no Subplot" 
+              : "no Subplot generated"; 
+          LOGGER.warn( plotNotFoundMsg);
+        }
+      }
+        
+    }
+  }
   
   public void reSelectSimulation(FskPortObject fskObj, int index) {
     fskObj.selectedSimulationIndex = index;


### PR DESCRIPTION
Target 4_4: plot of individual sub-models are copied to generated
Resources folder

The image files can be accessed by using the flow-variable "SubPlots"
generated by the Runner at the end of executing a combined model.