### PR TITLE
if RConda then .fsk folder is ignored

### DIFF
--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/LibRegistry.java
@@ -84,7 +84,7 @@ public class LibRegistry {
     // Prepare rWrapper
     rWrapper = new RWrapper();
     rWrapper.library("miniCRAN");
-    if((!PreferenceInitializer.getRPath().contains(RprofileManager.BFR_R_PLUGIN_NAME) &&  Platform.isWindows()) || Platform.isMac()) {
+    if((!PreferenceInitializer.getRPath().contains(RprofileManager.BFR_R_PLUGIN_NAME) &&  Platform.isWindows()) || PreferenceInitializer.isRConda()) {
       try {
         String[] rPath= controller.eval(".libPaths()", true).asStrings();
         //get default library path.
@@ -165,7 +165,7 @@ public class LibRegistry {
   public synchronized void install(final List<String> packages)
       throws RException, REXPMismatchException, NoInternetException {
 	  
-    if (Platform.isLinux() || Platform.isMac()) {
+    if ((Platform.isLinux() && !PreferenceInitializer.isRConda()) || Platform.isMac()) {
       // Install missing packages
       controller.addPackagePath(installPath);
       

--- a/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/RprofileManager.java
+++ b/de.bund.bfr.knime.fsklab.r/src/de/bund/bfr/knime/fsklab/r/client/RprofileManager.java
@@ -15,7 +15,7 @@ public class RprofileManager {
   public static void subscribe() throws IOException {
     try {
       lock.lock();
-      if (rHandlerCount++ == 0 && (PreferenceInitializer.getRPath().contains(BFR_R_PLUGIN_NAME) || Platform.isLinux())) {
+      if (rHandlerCount++ == 0 && (PreferenceInitializer.getRPath().contains(BFR_R_PLUGIN_NAME) || (Platform.isLinux() && !PreferenceInitializer.isRConda()))) {
         RConnectionFactory.createFskLibrary();
         RConnectionFactory.backupProfile();
         RConnectionFactory.configureProfile();
@@ -28,7 +28,7 @@ public class RprofileManager {
   public synchronized static void unSubscribe() throws IOException {
     try {
       lock.lock();
-      if (--rHandlerCount == 0 && PreferenceInitializer.isRProfileToBeRestored() && (PreferenceInitializer.getRPath().contains(BFR_R_PLUGIN_NAME) || Platform.isLinux())) {
+      if (--rHandlerCount == 0 && PreferenceInitializer.isRProfileToBeRestored() && (PreferenceInitializer.getRPath().contains(BFR_R_PLUGIN_NAME) || (Platform.isLinux() && !PreferenceInitializer.isRConda()))) {
         RConnectionFactory.restoreProfile();
       }
     } finally {


### PR DESCRIPTION
This change is necessary if there is a .fsk folder on Linux. If a Conda environment is set for R, the .fsk will have a negative effect leading to library errors