### PR TITLE
Feature request infuse simulation into sim config via flow variable

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/simulator/JSSimulatorNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/simulator/JSSimulatorNodeModel.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.knime.core.node.CanceledExecutionException;
@@ -337,7 +338,8 @@ class JSSimulatorNodeModel
             
             URI u = new URI(paramValue);
             if(u.getScheme() != null){
-              String fileParam = downloadOnlineRecourceToWorkingDir(paramValue,
+              
+              String fileParam = downloadOnlineRecourceToWorkingDir(u,
                   workingDirectory.get().toString());
               fskSimulation.getParameters().put(paramName, "\"" + fileParam + "\"");
             }
@@ -476,17 +478,16 @@ class JSSimulatorNodeModel
   /**
    * Downloads a file from a URL.The code here is considering that the fileURL defines a file URI scheme
    * https://en.wikipedia.org/wiki/File_URI_scheme
-   * @param fileURL URL of the file to be downloaded
+   * @param u URL of the file to be downloaded
    * @param workingDir path of the directory to save the file
    * @throws IOException
    * @throws URISyntaxException
    * @throws InvalidSettingsException
    */
-  public String downloadOnlineRecourceToWorkingDir(String fileURL, String workingDir) throws IOException {
-    String fileName = fileURL.substring(fileURL.lastIndexOf(File.separator) + 1, fileURL.length());
+  public String downloadOnlineRecourceToWorkingDir(URI u, String workingDir) throws IOException {
+    String fileName = FilenameUtils.getName(u.getPath());
     String destinationPath = workingDir + File.separator + fileName;    
-    URL website = new URL(fileURL);
-    ReadableByteChannel rbc = Channels.newChannel(website.openStream());
+    ReadableByteChannel rbc = Channels.newChannel(u.toURL().openStream());
     try (FileOutputStream fos = new FileOutputStream(destinationPath)) {
       fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
     }

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/simulator/JSSimulatorNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/simulator/JSSimulatorNodeModel.java
@@ -272,16 +272,17 @@ class JSSimulatorNodeModel
 
   public JsonNode getJSONIfValid(Map<String, FlowVariable> variableMap) {
     JsonNode simulationJson = null;
+    
     ObjectMapper mapper = new ObjectMapper()
         .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
-    
-    for(String paramName : variableMap.keySet()) {
+    //TODO: Have a Flow-Variable in Simulator Node Dialog so a simulation can
+    // have a custom name
+    if(variableMap.keySet().contains("injectedSimulation")) {
       try {
-        simulationJson  = mapper.readTree(variableMap.get(paramName).getStringValue());
+        simulationJson  = mapper.readTree(variableMap.get("injectedSimulation").getStringValue());
       } catch (JsonProcessingException e) {
     	    LOGGER.warn("Invalid JSON Object provided via Flow Variable");
       }
-      
     }
     return simulationJson;
   }

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/simulator/JSSimulatorNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/simulator/JSSimulatorNodeModel.java
@@ -277,7 +277,8 @@ class JSSimulatorNodeModel
     
     for(String paramName : variableMap.keySet()) {
       try {
-        simulationJson  = mapper.readTree(variableMap.get(paramName).getStringValue());
+        String value = variableMap.get(paramName).getStringValue();
+        simulationJson  = mapper.readTree(value);
       } catch (JsonProcessingException e) {
     	    LOGGER.warn("Invalid JSON Object provided via Flow Variable");
       }

--- a/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/simulator/JSSimulatorNodeModel.java
+++ b/de.bund.bfr.knime.fsklab.nodes/src/de/bund/bfr/knime/fsklab/v2_0/simulator/JSSimulatorNodeModel.java
@@ -277,8 +277,7 @@ class JSSimulatorNodeModel
     
     for(String paramName : variableMap.keySet()) {
       try {
-        String value = variableMap.get(paramName).getStringValue();
-        simulationJson  = mapper.readTree(value);
+        simulationJson  = mapper.readTree(variableMap.get(paramName).getStringValue());
       } catch (JsonProcessingException e) {
     	    LOGGER.warn("Invalid JSON Object provided via Flow Variable");
       }


### PR DESCRIPTION
This way any file with URI scheme used in the begining like : http, https, ftp, file:// will be downloaded 
the simulation can be provided as a json object where parameters and values provided as pair like
{
    "name": "value"
}
if the name doesn't exist in the parameter list of the model then it'll be ignored.
