### PR TITLE
Add jdom and jdom-contrib to build.properties

### DIFF
--- a/de.bund.bfr.knime.fsklab.nodes/build.properties
+++ b/de.bund.bfr.knime.fsklab.nodes/build.properties
@@ -15,6 +15,8 @@ bin.includes = META-INF/,\
                data/convertToJsonSerializable.py,\
                libs/vocabularies-2.0.0.jar,\
                libs/jackson-module-jsonschema-2.2.1.jar,\
-               data/filetype_blacklist.csv
+               data/filetype_blacklist.csv,\
+               sedml_libs/jdom-contrib-1.1.3.jar,\
+               sedml_libs/jdom-1.1.3.jar
 source.. = src/
            output.. = bin/


### PR DESCRIPTION
In the plugin de.bund.bfr.knime.fsklab.nodes the two libraries were missing in the buld.properties:
- jdom-1.1.3.jar
- jdom-contrib-1.1.3.jar